### PR TITLE
Mutation filtering in LinearOperators

### DIFF
--- a/grapp/linalg/ops_scipy.py
+++ b/grapp/linalg/ops_scipy.py
@@ -432,25 +432,78 @@ class SciPyStdXXTOperator(LinearOperator):
 
 
 class MultiSciPyXOperator(LinearOperator):
+    """
+    A scipy.sparse.linalg.LinearOperator on multiple GRGs. Same as SciPyXOperator, except if the input
+    GRGs have mutation counts M1, M2, ..., MK, then the dimension of the implicit underlying genotype
+    matrix is Nx(M1 + M2 + ... + MK).
+
+    :param grgs: The GRGs the operator will multiply against. They must all have the same samples,
+        and the mutations are expected to differ (e.g., one GRG per chromosome of the same dataset).
+    :type grgs: List[pygrgl.GRG]
+    :param direction: Determines whether the matrix is :math:`X` (pygrgl.TraversalDirection.UP) or
+        :math:`X^T` (pygrgl.TraversalDirection.DOWN).
+    :type direction: pygrgl.TraversalDirection
+    :param dtype: The numpy.dtype to use.
+    :type dtype: TypeAlias
+    :param haploid: Perform calculations on the {0, 1} haploid genotype matrix, instead of the {0, ..., grg.ploidy}
+        genotype matrix. Default: False.
+    :type haploid: bool
+    :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
+        mutation_filter) instead of NxM. Default: empty filter.
+    :type mutation_filter: Union[List[int], numpy.typing.NDArray]
+    :param threads: Number of threads for performing the multiplication. Each GRG can be done in
+        parallel.
+    :type threads: int
+    """
+
     def __init__(
         self,
         grgs: List[pygrgl.GRG],
         direction: pygrgl.TraversalDirection,
         dtype=numpy.float64,
         haploid: bool = False,
+        mutation_filter: Union[List[int], numpy.typing.NDArray] = [],
         threads: int = 1,
     ):
-        """
-        Operator that can take multiple GRGs (e.g., one for each chromosome) and perform a single operation
-        on all of them. We always assumes that the GRGs have the same sample set, but different mutation sets.
-        """
         assert len(grgs) >= 1, "Must provide at least one GRG"
-        self.operators = [SciPyXOperator(g, direction, dtype, haploid) for g in grgs]
         self.direction = direction
         self.num_mutations = sum([g.num_mutations for g in grgs])
+        self.mutation_filter = mutation_filter
+        if self.mutation_filter:
+            assert len(self.mutation_filter) <= self.num_mutations
+            self.num_mutations = len(self.mutation_filter)
+        self.operators = []
         num_samples = grgs[0].num_samples
-        for g in grgs[1:]:
+        prev_max_mut = 0
+        for g in grgs:
             assert g.num_samples == num_samples, "All GRGs must use the same samples"
+            if self.mutation_filter:
+                grg_mut_filt = list(
+                    map(
+                        lambda m: m - prev_max_mut,
+                        filter(
+                            lambda m: m >= prev_max_mut
+                            and m < prev_max_mut + g.num_mutations,
+                            self.mutation_filter,
+                        ),
+                    )
+                )
+                # If we have an overall filter, but no filter for _this_ GRG, then we just skip it.
+                skip = len(grg_mut_filt) == 0
+            else:
+                grg_mut_filt = []
+                skip = False
+            if not skip:
+                self.operators.append(
+                    SciPyXOperator(
+                        g,
+                        direction,
+                        dtype,
+                        haploid=haploid,
+                        mutation_filter=grg_mut_filt,
+                    )
+                )
+            prev_max_mut += g.num_mutations
         # Should we concatenate the result for _matmat, or add them together?
         self.concat = self.direction == pygrgl.TraversalDirection.DOWN
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
@@ -499,11 +552,33 @@ class MultiSciPyXOperator(LinearOperator):
 
 
 class MultiSciPyXTXOperator(LinearOperator):
+    """
+    A scipy.sparse.linalg.LinearOperator on multiple GRGs. Same as SciPyXTXOperator, except if the input
+    GRGs have mutation counts M1, M2, ..., MK, then the dimension of the implicit underlying genotype
+    matrix is Nx(M1 + M2 + ... + MK).
+
+    :param grgs: The GRGs the operator will multiply against. They must all have the same samples,
+        and the mutations are expected to differ (e.g., one GRG per chromosome of the same dataset).
+    :type grgs: List[pygrgl.GRG]
+    :param dtype: The numpy.dtype to use.
+    :type dtype: TypeAlias
+    :param haploid: Perform calculations on the {0, 1} haploid genotype matrix, instead of the {0, ..., grg.ploidy}
+        genotype matrix. Default: False.
+    :type haploid: bool
+    :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
+        mutation_filter) instead of NxM. Default: empty filter.
+    :type mutation_filter: Union[List[int], numpy.typing.NDArray]
+    :param threads: Number of threads for performing the multiplication. Each GRG can be done in
+        parallel.
+    :type threads: int
+    """
+
     def __init__(
         self,
         grgs: List[pygrgl.GRG],
         dtype=numpy.float64,
         haploid: bool = False,
+        mutation_filter: Union[List[int], numpy.typing.NDArray] = [],
         threads: int = 1,
     ):
         self.x_op = MultiSciPyXOperator(
@@ -511,6 +586,7 @@ class MultiSciPyXTXOperator(LinearOperator):
             pygrgl.TraversalDirection.UP,
             dtype=dtype,
             haploid=haploid,
+            mutation_filter=mutation_filter,
             threads=threads,
         )
         xtx_shape = (self.x_op.num_mutations, self.x_op.num_mutations)
@@ -533,6 +609,30 @@ class MultiSciPyXTXOperator(LinearOperator):
 
 # FIXME this can be factored into a common base class with MultiSciPyXOperator
 class MultiSciPyStdXOperator(LinearOperator):
+    """
+    A scipy.sparse.linalg.LinearOperator on multiple GRGs. Same as SciPyStdXOperator, except if the input
+    GRGs have mutation counts M1, M2, ..., MK, then the dimension of the implicit underlying genotype
+    matrix is Nx(M1 + M2 + ... + MK).
+
+    :param grgs: The GRGs the operator will multiply against. They must all have the same samples,
+        and the mutations are expected to differ (e.g., one GRG per chromosome of the same dataset).
+    :type grgs: List[pygrgl.GRG]
+    :param direction: Determines whether the matrix is :math:`X` (pygrgl.TraversalDirection.UP) or
+        :math:`X^T` (pygrgl.TraversalDirection.DOWN).
+    :type direction: pygrgl.TraversalDirection
+    :param dtype: The numpy.dtype to use.
+    :type dtype: TypeAlias
+    :param haploid: Perform calculations on the {0, 1} haploid genotype matrix, instead of the {0, ..., grg.ploidy}
+        genotype matrix. Default: False.
+    :type haploid: bool
+    :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
+        mutation_filter) instead of NxM. Default: empty filter.
+    :type mutation_filter: Union[List[int], numpy.typing.NDArray]
+    :param threads: Number of threads for performing the multiplication. Each GRG can be done in
+        parallel.
+    :type threads: int
+    """
+
     def __init__(
         self,
         grgs: List[pygrgl.GRG],
@@ -540,23 +640,50 @@ class MultiSciPyStdXOperator(LinearOperator):
         freqs: List[numpy.typing.NDArray],
         haploid: bool = False,
         dtype=numpy.float64,
+        mutation_filter: Union[List[int], numpy.typing.NDArray] = [],
         threads: int = 1,
     ):
-        """
-        Operator that can take multiple GRGs (e.g., one for each chromosome) and perform a single operation
-        on all of them. We always assumes that the GRGs have the same sample set, but different mutation sets.
-        """
         assert len(grgs) >= 1, "Must provide at least one GRG"
         assert len(grgs) == len(freqs), "Must provide allele frequencies for every GRG"
-        self.operators = [
-            SciPyStdXOperator(g, direction, f, dtype, haploid=haploid)
-            for f, g in zip(freqs, grgs)
-        ]
         self.direction = direction
         self.num_mutations = sum([g.num_mutations for g in grgs])
         num_samples = grgs[0].num_samples
-        for g in grgs[1:]:
+        self.mutation_filter = mutation_filter
+        if self.mutation_filter:
+            assert len(self.mutation_filter) <= self.num_mutations
+            self.num_mutations = len(self.mutation_filter)
+        prev_max_mut = 0
+        self.operators = []
+        for g, f in zip(grgs, freqs):
             assert g.num_samples == num_samples, "All GRGs must use the same samples"
+            if self.mutation_filter:
+                grg_mut_filt = list(
+                    map(
+                        lambda m: m - prev_max_mut,
+                        filter(
+                            lambda m: m >= prev_max_mut
+                            and m < prev_max_mut + g.num_mutations,
+                            self.mutation_filter,
+                        ),
+                    )
+                )
+                # If we have an overall filter, but no filter for _this_ GRG, then we just skip it.
+                skip = len(grg_mut_filt) == 0
+            else:
+                grg_mut_filt = []
+                skip = False
+            if not skip:
+                self.operators.append(
+                    SciPyStdXOperator(
+                        g,
+                        direction,
+                        f,
+                        dtype,
+                        haploid=haploid,
+                        mutation_filter=grg_mut_filt,
+                    )
+                )
+            prev_max_mut += g.num_mutations
         # Should we concatenate the result for _matmat, or add them together?
         self.concat = self.direction == pygrgl.TraversalDirection.DOWN
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
@@ -607,12 +734,34 @@ class MultiSciPyStdXOperator(LinearOperator):
 
 
 class MultiSciPyStdXTXOperator(LinearOperator):
+    """
+    A scipy.sparse.linalg.LinearOperator on multiple GRGs. Same as SciPyStdXTXOperator, except if the input
+    GRGs have mutation counts M1, M2, ..., MK, then the dimension of the implicit underlying genotype
+    matrix is Nx(M1 + M2 + ... + MK).
+
+    :param grgs: The GRGs the operator will multiply against. They must all have the same samples,
+        and the mutations are expected to differ (e.g., one GRG per chromosome of the same dataset).
+    :type grgs: List[pygrgl.GRG]
+    :param dtype: The numpy.dtype to use.
+    :type dtype: TypeAlias
+    :param haploid: Perform calculations on the {0, 1} haploid genotype matrix, instead of the {0, ..., grg.ploidy}
+        genotype matrix. Default: False.
+    :type haploid: bool
+    :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
+        mutation_filter) instead of NxM. Default: empty filter.
+    :type mutation_filter: Union[List[int], numpy.typing.NDArray]
+    :param threads: Number of threads for performing the multiplication. Each GRG can be done in
+        parallel.
+    :type threads: int
+    """
+
     def __init__(
         self,
         grgs: List[pygrgl.GRG],
         freqs: List[numpy.typing.NDArray],
         haploid: bool = False,
         dtype=numpy.float64,
+        mutation_filter: Union[List[int], numpy.typing.NDArray] = [],
         threads: int = 1,
     ):
         self.std_x_op = MultiSciPyStdXOperator(
@@ -621,6 +770,7 @@ class MultiSciPyStdXTXOperator(LinearOperator):
             freqs,
             haploid=haploid,
             dtype=dtype,
+            mutation_filter=mutation_filter,
             threads=threads,
         )
         xtx_shape = (self.std_x_op.num_mutations, self.std_x_op.num_mutations)

--- a/test/linalg/test_ops.py
+++ b/test/linalg/test_ops.py
@@ -236,6 +236,53 @@ class TestLinearOperators(unittest.TestCase):
             full_dip_result, split_dip_result, atol=ABSOLUTE_TOLERANCE
         )
 
+        ### Test with a contiguous mutation filter
+        total_muts = sum([g.num_mutations for g in grgs])
+        keep_mutations = list(range(total_muts // 2))
+        random_input = numpy.random.standard_normal((K, len(keep_mutations))).T
+        grg_op = SciPyXOperator(
+            self.grg,
+            pygrgl.TraversalDirection.UP,
+            haploid=False,
+            mutation_filter=keep_mutations,
+        )
+        full_dip_result = grg_op._matmat(random_input)
+        multi_op = MultiSciPyXOperator(
+            grgs,
+            pygrgl.TraversalDirection.UP,
+            haploid=False,
+            mutation_filter=keep_mutations,
+            threads=JOBS,
+        )
+        split_dip_result = multi_op._matmat(random_input)
+        numpy.testing.assert_allclose(full_dip_result, split_dip_result)
+
+        ### Test with a scattered mutation filter
+        total_muts = sum([g.num_mutations for g in grgs])
+        keep_mutations = [i * 2 for i in range(total_muts // 2)]
+        random_input = numpy.random.standard_normal((K, len(keep_mutations))).T
+        freqs = allele_frequencies(self.grg)
+        freq_list = list(map(allele_frequencies, grgs))
+
+        grg_op = SciPyStdXOperator(
+            self.grg,
+            pygrgl.TraversalDirection.UP,
+            freqs,
+            haploid=False,
+            mutation_filter=keep_mutations,
+        )
+        full_dip_result = grg_op._matmat(random_input)
+        multi_op = MultiSciPyStdXOperator(
+            grgs,
+            pygrgl.TraversalDirection.UP,
+            freq_list,
+            haploid=False,
+            mutation_filter=keep_mutations,
+            threads=JOBS,
+        )
+        split_dip_result = multi_op._matmat(random_input)
+        numpy.testing.assert_allclose(full_dip_result, split_dip_result)
+
     def test_filtering(self):
         """
         Test the operators with filters enabled.


### PR DESCRIPTION
Sometimes you want to perform a multiplication on a subset of the genotype matrix without having to filter the GRG and create a new file. This change supports this, if you want to filter on Mutations (not samples) -- for samples, you should still use `grapp filter` and just reduce the GRG.

New `mutation_filter=[...]` option to all operators. You specify the list of MutationIDs (i.e., indexes into the vector of mutations, starting at `0`) to keep. Works for regular and multi-GRG operators.