### PR TITLE
Filter multiple GRGs in a single API call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Example to build:
+#   docker build . -t grapp:latest
+# Example to run:
+#   docker run -v $PWD:/working -it grapp:latest grapp filter -r 0-10000 /working/input.grg /working/output.grg
+
+FROM ubuntu:22.04
+
+RUN apt update && \
+    apt install -y python3 python3-setuptools python3-pip python-is-python3 lz4 time && \
+    pip install pygrgl && \
+    pip install igdtools
+
+COPY . /grapp
+RUN pip install /grapp

--- a/grapp/util/filter.py
+++ b/grapp/util/filter.py
@@ -4,8 +4,8 @@ Functions for filtering data out of a GRG to create a new, smaller GRG.
 
 from multiprocessing import Pool
 from typing import List, Tuple, Optional, Union, Callable
-import pygrgl
 import os
+import pygrgl
 
 from grapp.util.simple import UserInputError, allele_frequencies
 
@@ -178,6 +178,61 @@ def grg_save_mut_filter(
         seeds,
         bp_range=bp_range,
     )
+
+
+def multi_grg_save_mut_filter(
+    grgs_or_filenames: Union[List[pygrgl.GRG], List[str]],
+    out_filenames: List[str],
+    mut_filter: Callable[[pygrgl.GRG, int, int], bool],
+):
+    """
+    Given a list of GRG filenames or GRG objects, save a new GRG for each that contains only the
+    Mutations selected by the given filter function. The callback takes the GRG, the MutationID
+    within that GRG, and the "cumulative MutationID" when considering all GRGs sequentially (e.g.
+    the second GRG's mutations start counting right after the last MutationID of the first GRG).
+
+    :param grgs_or_filenames: Either a pygrgl.GRG object, or the filename of a GRG.
+    :type grgs_or_filenames: Union[List[pygrgl.GRG], List[str]]
+    :param out_filenames: The list of filenames of the to-be-created GRGs.
+    :type out_filename: List[str]
+    :param mut_filter: Callback (function) that takes a MutationID (int) as input and returns
+        true if that mutation should be kept.
+    :type mut_filter: Callable[[pygrgl.GRG, int, int], bool]
+    """
+    assert len(grgs_or_filenames) > 0
+    assert len(grgs_or_filenames) == len(
+        out_filenames
+    ), "Input and output lists must be equal length"
+
+    if isinstance(grgs_or_filenames[0], str):
+        grgs = [
+            pygrgl.load_immutable_grg(f, load_up_edges=False) for f in grgs_or_filenames
+        ]
+    else:
+        assert isinstance(grgs_or_filenames[0], pygrgl.GRG)
+        grgs = grgs_or_filenames
+
+    def filter_one(grg, seeds, out_filename):
+        pygrgl.save_subset(
+            grg,
+            out_filename,
+            pygrgl.TraversalDirection.DOWN,
+            seeds,
+        )
+
+    prev_mut_id = 0
+    for out, grg in zip(out_filenames, grgs):
+        seeds = list(
+            filter(
+                lambda m: mut_filter(grg, m, m + prev_mut_id), range(grg.num_mutations)
+            )
+        )
+        if not seeds:
+            raise UserInputError(
+                "No Mutations found matching range; cannot filter to an empty GRG."
+            )
+        filter_one(grg, seeds, out)
+        prev_mut_id += grg.num_mutations
 
 
 def split_by_ranges(

--- a/test/linalg/test_ops.py
+++ b/test/linalg/test_ops.py
@@ -20,36 +20,13 @@ import unittest
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(THIS_DIR, ".."))
-from testing_utils import construct_grg, standardize_X, grg2X
+from testing_utils import construct_grg, standardize_X, grg2X, split_and_load
 
 CLEANUP = True
 JOBS = 4
 
 # Absolute error tolerated between numpy and GRG methods.
 ABSOLUTE_TOLERANCE = 1e-10
-
-
-def split_and_load(grg_filename: str, out_dir: str, cleanup: bool = True):
-    subprocess.check_output(
-        [
-            "grg",
-            "split",
-            "-j",
-            str(JOBS),
-            grg_filename,
-            "-s",
-            str(1_000_000),
-            "-o",
-            out_dir,
-        ]
-    )
-    grgs = []
-    for fn in glob.glob(os.path.join(out_dir, "*.grg")):
-        grgs.append(pygrgl.load_immutable_grg(fn))
-    grgs.sort(key=lambda g: g.bp_range[0])
-    if cleanup:
-        shutil.rmtree(out_dir)
-    return grgs
 
 
 class TestLinearOperators(unittest.TestCase):
@@ -158,7 +135,7 @@ class TestLinearOperators(unittest.TestCase):
 
         # Split the graph and get the multiple GRGs, for testing all of the below.
         test_dir = "test.multi_ops.split"
-        grgs = split_and_load(self.grg_filename, test_dir, CLEANUP)
+        grgs = split_and_load(self.grg_filename, test_dir, 1_000_000, JOBS, CLEANUP)
 
         #### Direction == UP
         K = 10
@@ -299,24 +276,24 @@ class TestLinearOperators(unittest.TestCase):
         freqs = allele_frequencies(self.grg)
         freq_list = list(map(allele_frequencies, grgs))
 
-        grg_op = SciPyStdXOperator(
+        grg_op = SciPyStdXTXOperator(
             self.grg,
-            pygrgl.TraversalDirection.UP,
             freqs,
             haploid=False,
             mutation_filter=keep_mutations,
         )
         full_dip_result = grg_op._matmat(random_input)
-        multi_op = MultiSciPyStdXOperator(
+        multi_op = MultiSciPyStdXTXOperator(
             grgs,
-            pygrgl.TraversalDirection.UP,
             freq_list,
             haploid=False,
             mutation_filter=keep_mutations,
             threads=JOBS,
         )
         split_dip_result = multi_op._matmat(random_input)
-        numpy.testing.assert_allclose(full_dip_result, split_dip_result)
+        numpy.testing.assert_allclose(
+            full_dip_result, split_dip_result, atol=ABSOLUTE_TOLERANCE
+        )
         # Vector version
         vec_result = grg_op._matvec(random_input[:, 1])
         split_vec_result = multi_op._matvec(random_input[:, 1])
@@ -325,7 +302,7 @@ class TestLinearOperators(unittest.TestCase):
         )
 
         # Reverse direction
-        random_input = numpy.random.standard_normal((K, self.grg.num_individuals)).T
+        # random_input = numpy.random.standard_normal((K, self.grg.num_individuals)).T
         rev_result = grg_op._rmatmat(random_input)
         split_rev_result = multi_op._rmatmat(random_input)
         numpy.testing.assert_allclose(

--- a/test/testing_utils.py
+++ b/test/testing_utils.py
@@ -1,7 +1,9 @@
-from typing import Optional
+from typing import Optional, List
+import glob
 import numpy
 import os
 import pygrgl
+import shutil
 import subprocess
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -87,3 +89,36 @@ def standardize_X(X: numpy.ndarray):
     # re-zero freq 1 cols
     Xstd[:, zero_sigma] = 0
     return Xstd
+
+
+# Split a GRG and load all the parts, and returns them _sorted by position_
+def split_and_load(
+    grg_filename: str,
+    out_dir: str,
+    size_per: int,
+    jobs: int,
+    cleanup: bool = True,
+    filenames: Optional[List] = None,
+):
+    subprocess.check_output(
+        [
+            "grg",
+            "split",
+            "-j",
+            str(jobs),
+            grg_filename,
+            "-s",
+            str(size_per),
+            "-o",
+            out_dir,
+        ]
+    )
+    grgs = []
+    for fn in glob.glob(os.path.join(out_dir, "*.grg")):
+        grgs.append(pygrgl.load_immutable_grg(fn))
+        if filenames is not None:
+            filenames.append(fn)
+    grgs.sort(key=lambda g: g.bp_range[0])
+    if cleanup:
+        shutil.rmtree(out_dir)
+    return grgs

--- a/test/util/test_filt.py
+++ b/test/util/test_filt.py
@@ -1,14 +1,20 @@
-from grapp.util.filter import grg_save_freq
+from grapp.util.filter import (
+    grg_save_freq,
+    grg_save_mut_filter,
+    multi_grg_save_mut_filter,
+)
 from grapp.util.simple import allele_counts, allele_frequencies
 import pygrgl
 import os
 import unittest
+import subprocess
 import sys
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(THIS_DIR, ".."))
-from testing_utils import construct_grg
+from testing_utils import construct_grg, split_and_load
 
+JOBS = 4
 CLEANUP = True
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -44,6 +50,44 @@ class TestFilter(unittest.TestCase):
                 self.assertFalse((mut.position, mut.allele) in seen)
             else:
                 self.assertTrue((mut.position, mut.allele) in seen)
+
+    def test_multi_filt(self):
+        full_freqs = allele_frequencies(self.grg)
+        freq_range = (0.2, 0.8)
+
+        test_filename = "test.filt.multi.grg"
+
+        def keep_mut(grg: pygrgl.GRG, mut_id: int):
+            return (
+                full_freqs[mut_id] >= freq_range[0]
+                and full_freqs[mut_id] < freq_range[1]
+            )
+
+        grg_save_mut_filter(self.grg, test_filename, keep_mut)
+
+        test_dir = "test.filt.multi.split"
+        partial_grgs = split_and_load(
+            self.grg_filename, test_dir, 5_000_000, JOBS, CLEANUP
+        )
+        partial_filenames = [
+            f"test.filt.multi.{i}.grg" for i in range(len(partial_grgs))
+        ]
+
+        def keep_mut_multi(grg: pygrgl.GRG, mut_id: int, cumu_id: int):
+            return (
+                full_freqs[cumu_id] >= freq_range[0]
+                and full_freqs[cumu_id] < freq_range[1]
+            )
+
+        multi_grg_save_mut_filter(partial_grgs, partial_filenames, keep_mut_multi)
+
+        merged_file = "test.filt.multi.merged.grg"
+        assert len(partial_filenames) > 0
+        subprocess.check_call(["grg", "merge", merged_file] + partial_filenames)
+
+        single_result = pygrgl.load_immutable_grg(test_filename)
+        merged_result = pygrgl.load_immutable_grg(merged_file)
+        self.assertEqual(single_result.num_mutations, merged_result.num_mutations)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Useful for processing multiple chromosomes at once. The LinearOperators support this multiple processing, so it is nice to be able to take the results from that and use it to filter the GRGs as well.