### PR TITLE
Add new "grapp pheno" CLI for simple phenotype simulation

### DIFF
--- a/grapp/cli/main.py
+++ b/grapp/cli/main.py
@@ -3,6 +3,7 @@ from grapp.cli import export_cli
 from grapp.cli import filter_cli
 from grapp.cli import pca_cli
 from grapp.cli import show_cli
+from grapp.cli import pheno_cli
 from grapp.util.simple import UserInputError
 
 import argparse
@@ -13,6 +14,7 @@ CMD_PCA = "pca"
 CMD_EXPORT = "export"
 CMD_FILTER = "filter"
 CMD_SHOW = "show"
+CMD_PHENO = "pheno"
 
 
 def main():
@@ -43,6 +45,11 @@ def main():
         help="Show data from a GRG.",
     )
     show_cli.add_options(show_parser)
+    pheno_parser = subparsers.add_parser(
+        CMD_PHENO,
+        help="Simulate phenotypes with a GRG.",
+    )
+    pheno_cli.add_options(pheno_parser)
 
     try:
         args = parser.parse_args()
@@ -60,6 +67,8 @@ def main():
             filter_cli.run(args)
         elif args.command == CMD_SHOW:
             show_cli.run(args)
+        elif args.command == CMD_PHENO:
+            pheno_cli.run(args)
         else:
             print(f"Invalid command {args.command}", file=sys.stderr)
             parser.print_help()

--- a/grapp/cli/pheno_cli.py
+++ b/grapp/cli/pheno_cli.py
@@ -1,0 +1,66 @@
+from grg_pheno_sim.phenotype import sim_phenotypes
+import argparse
+import os
+import pygrgl
+
+
+def add_options(subparser):
+    subparser.add_argument("grg_input", help="The input GRG file")
+    subparser.add_argument(
+        "-e",
+        "--heritability",
+        default=0.33,
+        type=float,
+        help="The heritability (h^2) of the simulated trait. Default: 0.33.",
+    )
+    subparser.add_argument(
+        "-n",
+        "--num-causal",
+        default=None,
+        help="Number of causal variants to simulate. Default: every variant is causal.",
+    )
+    subparser.add_argument(
+        "--seed",
+        default=42,
+        type=int,
+        help="Random seed. Default: 42",
+    )
+    subparser.add_argument(
+        "--no-normalize",
+        action="store_true",
+        help="Don't normalize the final phenotype values.",
+    )
+    subparser.add_argument(
+        "--save-effects",
+        action="store_true",
+        help="Write file <grg_input>.effects.par, containing the per-SNP effect sizes.",
+    )
+
+
+def run(args):
+    base = os.path.basename(args.grg_input)
+    effect_path = f"{base}.effects.par"
+    output_path = f"{base}.phen"
+    grg = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
+    sim_phenotypes(
+        grg,
+        num_causal=args.num_causal,
+        random_seed=args.seed,
+        normalize_phenotype=not args.no_normalize,
+        normalize_genetic_values_before_noise=True,
+        heritability=args.heritability,
+        save_effect_output=args.save_effects,
+        effect_path=effect_path,
+        standardized_output=True,
+        path=output_path,
+        header=True,
+    )
+    print()
+    print(f"Wrote phenotypes to {output_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    add_options(parser)
+    args = parser.parse_args()
+    run(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+grg_pheno_sim>=1.4
 numpy
 pandas
 pygrgl>=2.5
 pyigd>=1.3
-scipy
 scikit-learn
+scipy


### PR DESCRIPTION
grg_pheno_sim stands on its own for full featured simulation, with a lot of options. but if you just want something simple, you can use "grapp pheno" to call grg_pheno_sim with the typical options.