### PR TITLE
Center the C matrix (column-wise) prior to QR decomposition

### DIFF
--- a/grapp/assoc/__init__.py
+++ b/grapp/assoc/__init__.py
@@ -30,21 +30,17 @@ def _div_or_default(a, b, d):
     :param b: Denominator
     :param d: Default value for when denominator is 0.
     """
-    result = numpy.full(b.shape, d)
+    result = numpy.full(a.shape, d)
     return numpy.divide(a, b, out=result, where=(b != 0))
 
 
-def read_plink_covariates(
-    covar_path: str, add_intercept: bool = True
-) -> numpy.typing.NDArray:
+def read_plink_covariates(covar_path: str) -> numpy.typing.NDArray:
     """
     Reads a PLINK-style covariate file (no headers) and returns a NumPy matrix of covariate values.
     The first two columns (FID/IID) are ignored. Optionally adds an intercept column of 1s.
 
     :param path: Path to the covariate file.
     :type path: str
-    :param add_intercept: If True, adds a column of 1s to the left of the matrix.
-    :type add_intercept: bool
     :return: A NumPy array of shape (n_samples, n_covariates [+1 if intercept]).
     :rtype: numpy.ndarray
     """
@@ -60,10 +56,6 @@ def read_plink_covariates(
 
     # stack into (n_samples × K)
     X = numpy.vstack(rows) if rows else numpy.empty((0, 0))
-
-    if add_intercept and X.size:
-        intercept = numpy.ones((X.shape[0], 1))
-        X = numpy.hstack([intercept, X])
 
     return X
 
@@ -344,7 +336,8 @@ def linear_assoc_covar(
     # QR decompose the centered covariate matrix. The linear regression of Yadj and Xadj
     # has an error term that is based on C and epsilon (the original, unadjusted error term).
     # This new error term must be 0-centered, so we center C here.
-    Q, R = numpy.linalg.qr(C - numpy.mean(C, axis=0))
+    centeredC = C - numpy.mean(C, axis=0)
+    Q, R = numpy.linalg.qr(centeredC)
 
     # Compute Y adj
     Yadj = Y - Q @ (Q.T @ Y)

--- a/grapp/cli/assoc_cli.py
+++ b/grapp/cli/assoc_cli.py
@@ -30,11 +30,24 @@ def add_options(subparser):
         default=None,
         help="Tab-separated output file (with header); exported Pandas DataFrame. Default: <grg_input>.assoc.tsv",
     )
+    subparser.add_argument(
+        "-r",
+        "--regress-y",
+        action="store_true",
+        help="Use linear regression to regress the covariates out of Y only. By default, QR decomposition is used to adjust both X and Y for covariates.",
+    )
+    subparser.add_argument(
+        "-s",
+        "--standardize",
+        action="store_true",
+        help="Standardize the X and Y matrices prior to performing linear regression.",
+    )
 
 
 def run(args):
     g = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
     if args.phenotypes is None:
+        print("No phenotype provided; randomly generating phenotype values")
         y = numpy.random.standard_normal(g.num_individuals)
     else:
         y = read_pheno(args.phenotypes)
@@ -44,15 +57,19 @@ def run(args):
 
     if args.covariates is not None:
         if args.covariates.endswith(".txt"):
-            C = read_plink_covariates(args.covariates, True)
+            C = read_plink_covariates(args.covariates)
         else:
             assert args.covariates.endswith(
                 ".tsv"
             ), "Covariates filename must end in .txt (plink format) or .tsv (pandas dataframe)"
             C = pandas.read_csv(args.covariates, delimiter="\t").to_numpy()
-        gwas_df = linear_assoc_covar(g, y, C)
+        method = "regress" if args.regress_y else "QR"
+        gwas_df = linear_assoc_covar(
+            g, y, C, method=method, standardize=args.standardize
+        )
     else:
-        gwas_df = linear_assoc_no_covar(g, y)
+        assert not args.regress_y, "--regress-y doesn't apply to non-covariate GWAS"
+        gwas_df = linear_assoc_no_covar(g, y, standardize=args.standardize)
 
     if args.out_file is None:
         args.out_file = f"{os.path.basename(args.grg_input)}.assoc.tsv"

--- a/grapp/cli/pca_cli.py
+++ b/grapp/cli/pca_cli.py
@@ -41,6 +41,7 @@ def run(args):
     if args.pcs_out is None:
         args.pcs_out = f"{os.path.basename(args.grg_input)}.pcs.tsv"
     pandas_to_tsv(args.pcs_out, scores)
+    print(f"Wrote PCs to {args.pcs_out}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The adjusted linear regression for the QR method is Yadj = Xadj*beta + epsilon'

Where epsilon' is a function of C (covariate matrix) and epsilon (the original error term). We need the adjusted epsilon' to be normally distributed and centered at 0, so we center the matrix C to help ensure this.