### PR TITLE
Fix documentation build, export allele_counts to util API

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,7 @@
-sphinx-rtd-theme
 numpy
+pandas
+pygrgl
+pyigd
+scipy
+scikit-learn
+sphinx-rtd-theme

--- a/grapp/util/__init__.py
+++ b/grapp/util/__init__.py
@@ -1,1 +1,4 @@
-from .simple import allele_frequencies  # noqa: F401
+from .simple import (  # noqa: F401
+    allele_frequencies,
+    allele_counts,
+)


### PR DESCRIPTION
1. Documentation requirements.txt was missing some things
2. "from grapp.util import allele_counts" now supported