### PR TITLE
Adjust some PCA parameter names

### DIFF
--- a/grapp/cli/pca_cli.py
+++ b/grapp/cli/pca_cli.py
@@ -36,7 +36,9 @@ def add_options(subparser):
 
 def run(args):
     grg = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
-    scores = PCs(grg, args.dimensions, args.normalize, use_pro_pca=args.pro_pca)
+    scores = PCs(
+        grg, k=args.dimensions, unitvar=args.normalize, use_pro_pca=args.pro_pca
+    )
 
     if args.pcs_out is None:
         args.pcs_out = f"{os.path.basename(args.grg_input)}.pcs.tsv"

--- a/grapp/linalg/__init__.py
+++ b/grapp/linalg/__init__.py
@@ -47,7 +47,7 @@ def sort_by_eigvalues(
 def eigs(
     matrix: MatrixSelection,
     grg: pygrgl.GRG,
-    first_k: int,
+    k: int,
     standardized: bool = True,
     haploid: bool = False,
 ) -> Tuple[NDArray, NDArray]:
@@ -59,15 +59,15 @@ def eigs(
     :type matrix: MatrixSelection
     :param grg: The GRG to operate on.
     :type grg: pygrgl.GRG
-    :param first_k: The number of (largest) eigen values/vectors to retrieve.
-    :type first_k: int
+    :param k: The number of (largest) eigen values/vectors to retrieve.
+    :type k: int
     :param standardized: Set to False to use the non-standardized matrix. Default: True.
     :type standardized: bool
     :param haploid: Set to True to use the haploid values (0,1) instead of diploid values (0,1,2).
     :type haploid: bool
     :return: (eigen_value, eigen_vectors) as defined by scipy.sparse.linalg.eigs
     """
-    first_k = min(first_k, grg.num_mutations)
+    k = min(k, grg.num_mutations)
     freqs = allele_frequencies(grg)
 
     if matrix == MatrixSelection.X:
@@ -93,21 +93,21 @@ def eigs(
             operator = _SciPyStdXTXOperator(grg, freqs, haploid=haploid)
         else:
             operator = _SciPyXTXOperator(grg, freqs, haploid=haploid)
-    eigen_values, eigen_vectors = _scipy_eigs(operator, k=first_k, which="LR")
+    eigen_values, eigen_vectors = _scipy_eigs(operator, k=k, which="LR")
     sort_by_eigvalues(eigen_values, eigen_vectors)
     return eigen_values, eigen_vectors
 
 
-def get_eig_pcs(grg: pygrgl.GRG, first_k: int) -> Tuple[NDArray, NDArray, NDArray]:
+def get_eig_pcs(grg: pygrgl.GRG, k: int) -> Tuple[NDArray, NDArray, NDArray]:
     """
     Get the principle components for each sample corresponding to the first :math:`k` eigenvectors from a GRG,
     using an iterative eigenvector decomposition method.
 
     :param grg: The GRG to perform PCA on.
     :type grg: pygrgl.GRG
-    :param first_k: The number of eigenvectors/values to use. These correspond to the `k` largest
+    :param k: The number of eigenvectors/values to use. These correspond to the `k` largest
         eigenvalues.
-    :type first_k: int
+    :type k: int
     :return: A triple (PC_scores, eigen_values, eigen_vectors) where each is a numpy array.
     :rtype: numpy.ndarray
     """
@@ -116,7 +116,7 @@ def get_eig_pcs(grg: pygrgl.GRG, first_k: int) -> Tuple[NDArray, NDArray, NDArra
 
     op = _SciPyStdXTXOperator(grg, freqs, haploid=False)
 
-    eigen_values, eigen_vectors = _scipy_eigs(op, k=first_k, which="LR")
+    eigen_values, eigen_vectors = _scipy_eigs(op, k=k, which="LR")
     sort_by_eigvalues(eigen_values, eigen_vectors)
 
     # Standardize all k eigenvectors at once: for later
@@ -129,7 +129,7 @@ def get_eig_pcs(grg: pygrgl.GRG, first_k: int) -> Tuple[NDArray, NDArray, NDArra
 
 def PCs(
     grg: pygrgl.GRG,
-    first_k: int,
+    k: int,
     unitvar: bool = True,
     include_eig: bool = False,
     use_pro_pca: bool = False,
@@ -139,9 +139,9 @@ def PCs(
 
     :param grg: The GRG to perform PCA on.
     :type grg: pygrgl.GRG
-    :param first_k: The number of eigenvectors/values to use. These correspond to the `k` largest
+    :param k: The number of eigenvectors/values to use. These correspond to the `k` largest
         eigenvalues.
-    :type first_k: int
+    :type k: int
     :param unitvar: When True, normalize the PCs by dividing by the square root of each
         corresponding eigenvalue. Default: True.
     :type unitvar: bool
@@ -151,11 +151,11 @@ def PCs(
     :return: A pandas.DataFrame with a row per individual and a column per principle component.
     :rtype: pandas.DataFrame
     """
-    first_k = min(first_k, grg.num_mutations)
+    k = min(k, grg.num_mutations)
     if use_pro_pca:
-        PC_scores, eigen_values, eigen_vectors = get_pcs_propca(grg, first_k)
+        PC_scores, eigen_values, eigen_vectors = get_pcs_propca(grg, k)
     else:
-        PC_scores, eigen_values, eigen_vectors = get_eig_pcs(grg, first_k)
+        PC_scores, eigen_values, eigen_vectors = get_eig_pcs(grg, k)
 
     if unitvar:
         PC_scores = PC_scores / numpy.sqrt(eigen_values.real)[None, :]

--- a/grapp/linalg/proPCA.py
+++ b/grapp/linalg/proPCA.py
@@ -10,17 +10,11 @@ def _EM(grg: pygrgl.GRG, C: NDArray, freqs: NDArray) -> NDArray:
     ###Compute E
     E = np.linalg.inv(C.T @ C) @ C.T
     ###Find stuff for standardization
-    X = (
-        _SciPyStdXOperator(grg, pygrgl.TraversalDirection.UP, freqs, haploid=False)
-        ._matmat(E.T)
-        .T
-    )
+    X = _SciPyStdXOperator(grg, pygrgl.TraversalDirection.UP, freqs)._matmat(E.T).T
     ###Compute M
     M = X.T @ np.linalg.inv(X @ X.T)
     ###Compute C
-    C = _SciPyStdXOperator(
-        grg, pygrgl.TraversalDirection.DOWN, freqs, haploid=False
-    )._matmat(M)
+    C = _SciPyStdXOperator(grg, pygrgl.TraversalDirection.DOWN, freqs)._matmat(M)
     ###Repeat
     return C
 
@@ -32,7 +26,7 @@ def _compute_pcs_from_C(
     Q, R = np.linalg.qr(C, mode="reduced")
 
     # 2 Project into that basis
-    B = _SciPyStdXOperator(grg, pygrgl.TraversalDirection.UP, freqs, False)._matmat(Q).T
+    B = _SciPyStdXOperator(grg, pygrgl.TraversalDirection.UP, freqs)._matmat(Q).T
 
     # 3 SVD of matrix B
     U, S, Vt = np.linalg.svd(B, full_matrices=False)

--- a/test/linalg/test_eigs.py
+++ b/test/linalg/test_eigs.py
@@ -1,6 +1,8 @@
 from grapp.linalg import (
     MatrixSelection,
+    PCs,
     eigs as grg_eigs,
+    get_pcs_propca,
     sort_by_eigvalues,
 )
 import pygrgl
@@ -46,6 +48,14 @@ class TestPCA(unittest.TestCase):
         for ev, gev in zip(evects.T, grg_evects.T):
             # Vectors may differ by sign.
             self.assertTrue(numpy.allclose(ev, gev) or numpy.allclose(-ev, gev))
+
+    # Just make sure PCA succeeds
+    def test_pca_smoketest(self):
+        PCs(self.grg, k=20)
+
+    # Just make sure PCA succeeds
+    def test_propca_smoketest(self):
+        get_pcs_propca(self.grg, k=20)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
1. ProPCA operators were being constructed without kwargs, which caused some errors.
2. Adjust all PCA-related functions to use "k=" for the number of PCs/eigenvectors to get.