### PR TITLE
Fix .shape on some Multi* operators, add options to some CLIs

### DIFF
--- a/grapp/cli/pheno_cli.py
+++ b/grapp/cli/pheno_cli.py
@@ -1,4 +1,4 @@
-from grg_pheno_sim.phenotype import sim_phenotypes
+from grg_pheno_sim.phenotype import sim_phenotypes, convert_to_phen
 import argparse
 import os
 import pygrgl
@@ -32,8 +32,13 @@ def add_options(subparser):
     )
     subparser.add_argument(
         "--save-effects",
-        action="store_true",
-        help="Write file <grg_input>.effects.par, containing the per-SNP effect sizes.",
+        help="Write the per-SNP effect sizes to the given filename.",
+    )
+    subparser.add_argument(
+        "-o",
+        "--out-file",
+        default=None,
+        help="Tab-separated output file (with header); exported Pandas DataFrame. Default: <grg_input>.phen",
     )
 
 
@@ -42,19 +47,21 @@ def run(args):
     effect_path = f"{base}.effects.par"
     output_path = f"{base}.phen"
     grg = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
-    sim_phenotypes(
+    phenotypes = sim_phenotypes(
         grg,
         num_causal=args.num_causal,
         random_seed=args.seed,
         normalize_phenotype=not args.no_normalize,
         normalize_genetic_values_before_noise=True,
         heritability=args.heritability,
-        save_effect_output=args.save_effects,
-        effect_path=effect_path,
-        standardized_output=True,
-        path=output_path,
+        save_effect_output=bool(args.save_effects is not None),
+        effect_path=args.save_effects,
         header=True,
     )
+    if args.out_file is None:
+        args.out_file = output_path
+    convert_to_phen(phenotypes, args.out_file, include_header=True)
+
     print()
     print(f"Wrote phenotypes to {output_path}")
 

--- a/grapp/cli/show_cli.py
+++ b/grapp/cli/show_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import pygrgl
+from collections import defaultdict
 
 
 def add_options(subparser: argparse.ArgumentParser):
@@ -11,10 +12,30 @@ def add_options(subparser: argparse.ArgumentParser):
         action="store_true",
         help="Show the individual IDs.",
     )
+    whattoshow.add_argument(
+        "-P",
+        "--populations",
+        action="store_true",
+        help="Show the population information.",
+    )
 
 
 def run(args):
+    grg = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
+    print(f"Mutations: {grg.num_mutations}")
+    print(f"Samples: {grg.num_samples}")
+    print(f"Individuals: {grg.num_individuals}")
+    print(f"Phased? {'Yes' if grg.is_phased else 'No'}")
+    print(f"Nodes: {grg.num_nodes}")
+    print(f"Edges: {grg.num_edges}")
     if args.individuals:
-        grg = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
         if grg.has_individual_ids:
             print("\n".join(map(grg.get_individual_id, range(grg.num_individuals))))
+    if args.populations:
+        pop_labels = grg.get_populations()
+        if pop_labels:
+            by_pop = defaultdict(int)
+            for sample_id in range(grg.num_samples):
+                by_pop[grg.get_population_id(sample_id)] += 1
+            for p, label in enumerate(pop_labels):
+                print(f"{label}: {by_pop[p]}/{grg.num_samples} haplotypes")

--- a/grapp/linalg/ops_scipy.py
+++ b/grapp/linalg/ops_scipy.py
@@ -627,6 +627,7 @@ class MultiSciPyXOperator(LinearOperator):
             self.num_mutations = len(self.mutation_filter)
         self.operators = []
         num_samples = grgs[0].num_samples
+        num_indivs = grgs[0].num_individuals
         prev_miss_start = 0
         prev_max_mut = 0
         for g in grgs:
@@ -672,6 +673,11 @@ class MultiSciPyXOperator(LinearOperator):
         # Should we concatenate the result for _matmat, or add them together?
         self.concat = self.direction == pygrgl.TraversalDirection.DOWN
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
+        sample_count = num_samples if haploid else num_indivs
+        shape = (sample_count, self.num_mutations)
+        if direction == _DOWN:
+            shape = _transpose_shape(shape)
+        super().__init__(dtype=dtype, shape=shape)
 
     def _matmat_helper(self, other_matrix, direction, op_method):
         # For UP, we have "(N x M) x (M x k)", so we need to split the other_matrix into chunks of the
@@ -825,6 +831,7 @@ class MultiSciPyStdXOperator(LinearOperator):
         self.direction = direction
         self.num_mutations = sum([g.num_mutations for g in grgs])
         num_samples = grgs[0].num_samples
+        num_indivs = grgs[0].num_individuals
         self.mutation_filter = mutation_filter
         if mutation_filter is not None:
             assert len(self.mutation_filter) <= self.num_mutations  # type: ignore
@@ -864,6 +871,11 @@ class MultiSciPyStdXOperator(LinearOperator):
         # Should we concatenate the result for _matmat, or add them together?
         self.concat = self.direction == pygrgl.TraversalDirection.DOWN
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
+        sample_count = num_samples if haploid else num_indivs
+        shape = (sample_count, self.num_mutations)
+        if direction == _DOWN:
+            shape = _transpose_shape(shape)
+        super().__init__(dtype=dtype, shape=shape)
 
     def _matmat_helper(self, other_matrix, direction, op_method):
         # For UP, we have "(N x M) x (M x k)", so we need to split the other_matrix into chunks of the

--- a/test/linalg/test_ops.py
+++ b/test/linalg/test_ops.py
@@ -172,6 +172,7 @@ class TestLinearOperators(unittest.TestCase):
         multi_op = MultiSciPyXOperator(
             grgs, pygrgl.TraversalDirection.UP, haploid=False, threads=JOBS
         )
+        self.assertEqual(multi_op.shape, grg_op.shape)
         split_dip_result = multi_op._matmat(random_input)
         # Test equality
         numpy.testing.assert_allclose(full_dip_result, split_dip_result)
@@ -190,6 +191,7 @@ class TestLinearOperators(unittest.TestCase):
         multi_op = MultiSciPyXOperator(
             grgs, pygrgl.TraversalDirection.DOWN, haploid=False, threads=JOBS
         )
+        self.assertEqual(multi_op.shape, grg_op.shape)
         split_dip_result = multi_op._matmat(random_input)
         # Test equality
         numpy.testing.assert_allclose(full_dip_result, split_dip_result)
@@ -208,6 +210,7 @@ class TestLinearOperators(unittest.TestCase):
         full_dip_result = grg_op._matmat(random_input)
         # Result on the split graph
         multi_op = MultiSciPyXTXOperator(grgs, haploid=False, threads=JOBS)
+        self.assertEqual(multi_op.shape, grg_op.shape)
         split_dip_result = multi_op._matmat(random_input)
         # Test equality
         numpy.testing.assert_allclose(full_dip_result, split_dip_result)
@@ -232,6 +235,7 @@ class TestLinearOperators(unittest.TestCase):
         multi_op = MultiSciPyStdXOperator(
             grgs, pygrgl.TraversalDirection.UP, freq_list, haploid=False, threads=JOBS
         )
+        self.assertEqual(multi_op.shape, grg_op.shape)
         split_dip_result = multi_op._matmat(random_input)
         # Test equality
         numpy.testing.assert_allclose(full_dip_result, split_dip_result)
@@ -252,6 +256,7 @@ class TestLinearOperators(unittest.TestCase):
         multi_op = MultiSciPyStdXTXOperator(
             grgs, freq_list, haploid=False, threads=JOBS
         )
+        self.assertEqual(multi_op.shape, grg_op.shape)
         split_dip_result = multi_op._matmat(random_input)
         # Test equality
         numpy.testing.assert_allclose(
@@ -283,6 +288,7 @@ class TestLinearOperators(unittest.TestCase):
             mutation_filter=keep_mutations,
             threads=JOBS,
         )
+        self.assertEqual(multi_op.shape, grg_op.shape)
         split_dip_result = multi_op._matmat(random_input)
         numpy.testing.assert_allclose(full_dip_result, split_dip_result)
 
@@ -314,6 +320,7 @@ class TestLinearOperators(unittest.TestCase):
             mutation_filter=keep_mutations,
             threads=JOBS,
         )
+        self.assertEqual(multi_op.shape, grg_op.shape)
         split_dip_result = multi_op._matmat(random_input)
         numpy.testing.assert_allclose(
             full_dip_result, split_dip_result, atol=ABSOLUTE_TOLERANCE


### PR DESCRIPTION
* "grapp pheno" can now specify an output file for the phenotype
* "grapp show" dumps some basic statistics and also supports -P for showing population label information
* Multi* operators didn't have .shape set at all.