### PR TITLE
More mutation-based filtering from the command line

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1,0 +1,124 @@
+# grapp command-line cheat sheet
+
+A cheat sheet for commands that manipulate GRGs.
+
+### Filtering
+
+All variant-based filters can be combined together in a single command. A lot of the syntax matches
+that of `bcftools`.
+
+#### Extract a region of the genome
+
+```
+# Get a 1MB region in the "middle"  (20MBP to 21MBP)
+grapp filter -r 20000000-21000000 input.grg output.grg
+```
+
+#### Minor allele frequency >= 0.01
+
+```
+# Only keep variants with frequency >= 0.01 and <= 0.99 (minor allele may be reference)
+grapp filter -q 0.01 -Q 0.99 input.grg output.grg
+```
+
+#### Variants only
+
+```
+# Only keep variants if they have at least one sample (allele count >= 1)
+# Assume we have a dataset with 200 haplotypes in it
+grapp filter -c 1 -C 199 input.grg output.grg
+```
+
+#### Bi-allelic SNPs only
+
+```
+grapp filter -v snps -m 2 -M 2 input.grg output.grg
+```
+
+#### SNP/MNP _sites_ only
+
+```
+# This drops the entire site if any variant is not a SNP or MNP
+grapp filter -v snps,mnps -A input.grg output.grg
+```
+
+#### INDELs only
+
+```
+grapp filter -v indels input.grg output.grg
+```
+
+#### Keep individuals by population label
+
+```
+# The GRG file must have been created with population labels
+grapp filter -P EUR,YRI,CHB input.grg output.grg
+```
+
+#### Keep individuals by identifier
+
+```
+grapp filter -S indiv1,indiv5 input.grg output.grg
+
+# Or via a file containing one ID per line
+grapp filter -S keep_list.txt input.grg output.grg
+```
+
+#### Keep individuals by haplotype indices
+
+```
+# Keep the first and fifth diploid individual (both haplotypes for each)
+# You can also pass a file, like above
+grapp filter --hap-samples 0,1,10,11 input.grg output.grg
+```
+
+### Viewing and exporting information
+
+#### Show allele frequencies and counts
+
+```
+grapp show -f input.grg > frequencies.tsv
+grapp show -c input.grg > counts.tsv
+```
+
+#### Show GRG info and population labels
+
+```
+grapp show -i -P input.grg
+```
+
+#### Get individual identifiers
+
+```
+grapp show -S input.grg > individuals.txt
+```
+
+#### Export GRG to IGD format (tabular)
+
+```
+# The more threads (-j) the better!
+grapp export --igd output.igd -j 6 input.grg
+```
+
+### GWAS, PCA, and phenotypes
+
+#### Phenotype simulation
+
+```
+# Simulate a random phenotype with h^2=0.5 and 1000 causal SNPs
+grapp pheno -e 0.5 -n 1000 -o simulated.phenotypes.par input.grg
+```
+
+#### GWAS
+
+```
+# Perform GWAS between the GRG and the simulated phenotype
+grapp assoc -p simulated.phenotypes.par -o gwas_results.tsv input.grg
+```
+
+#### PCA
+
+```
+# Get the 10 largest PCs
+grapp pca -d 10 -o output.pcs.tsv input.grg
+```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ compressing large datasets significantly, while also making calculations over th
 
 Some notes on usage are below, and you can also browse [the Python documentation for grapp](https://grapp.readthedocs.io/en/latest/).
 
+Check out the [command-line cheatsheet](https://github.com/aprilweilab/grapp/blob/main/CHEATSHEET.md) for examples on how to perform many tasks.
+
 ## Installation
 
 ```
@@ -104,7 +106,8 @@ options:
 
 GRG files can be filtered, prior to performing analysis on them. See the filter command:
 ```
-usage: grapp filter [-h] (-S INDIVIDUALS | --hap-samples HAP_SAMPLES | -r RANGE) grg_input grg_output
+sage: grapp filter [-h] [-S INDIVIDUALS | --hap-samples HAP_SAMPLES | -P POPULATIONS] [-r RANGE] [-c MIN_AC] [-C MAX_AC] [-q MIN_AF] [-Q MAX_AF] [-v TYPES] [-A] [-m MIN_ALLELES] [-M MAX_ALLELES]
+                    grg_input grg_output
 
 positional arguments:
   grg_input             The input GRG file
@@ -112,17 +115,38 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+
+sample filters:
   -S INDIVIDUALS, --individuals INDIVIDUALS
                         Keep only the individuals with the IDs given as a comma-separated list or in the given filename.
   --hap-samples HAP_SAMPLES
                         Keep only the haploid samples with the NodeIDs (indexes) given as a comma-separated list or in the given filename.
+  -P POPULATIONS, --populations POPULATIONS
+                        Keep only the individuals with populations matching the comma-separated list or in the given filename.
+
+mutation filters:
   -r RANGE, --range RANGE
                         Keep only the variants within the given range, in base pairs. Example: "lower-upper", where both are integers and lower is inclusive, upper is exclusive.
+  -c MIN_AC, --min-ac MIN_AC
+                        Minimum allele count to keep. All Mutations with count below this value will be dropped
+  -C MAX_AC, --max-ac MAX_AC
+                        Maximum allele count to keep. All Mutations with count above this value will be dropped
+  -q MIN_AF, --min-af MIN_AF
+                        Minimum allele frequency to keep. All Mutations with frequency below this value will be dropped
+  -Q MAX_AF, --max-af MAX_AF
+                        Maximum allele frequency to keep. All Mutations with frequency above this value will be dropped
+  -v TYPES, --types TYPES
+                        Comma-separated list of variant types to select. Site is selected if any of the ALT alleles is of the type requested. Types are determined by comparing the REF and ALT alleles.
+  -A, --apply-to-sites  By default, all filters apply to each variant independently. This flag will cause an entire site to be dropped if any variants are filtered out.
+  -m MIN_ALLELES, --min-alleles MIN_ALLELES
+                        Only keep sites with at least this many alleles. Counts all REF alleles as 1.
+  -M MAX_ALLELES, --max-alleles MAX_ALLELES
+                        Only keep sites with at most this many alleles. Counts all REF alleles as 1. Use '-m 2 -M 2 -v snps' to view only biallelic SNPs.
 ```
 
 #### Library
 
-Library documentation will be generated soon.
+Library API reference document is [here](https://grapp.readthedocs.io/en/latest/). There are also some tutorials in the [GRG documentation](https://grgl.readthedocs.io/en/stable/tutorials/GWAS.html) (and correspond [Jupyter notebooks](https://github.com/aprilweilab/grgl/tree/main/doc/tutorials/notebooks)).
 
 ### nn
 

--- a/grapp/cli/filter_cli.py
+++ b/grapp/cli/filter_cli.py
@@ -1,6 +1,4 @@
-import argparse
-import os
-
+from enum import Enum
 from grapp.util.filter import (
     grg_save_individuals,
     grg_save_mut_filter,
@@ -12,15 +10,41 @@ from grapp.util.simple import (
     allele_counts,
     allele_frequencies,
 )
+from typing import Set
+import argparse
+import os
 import pygrgl
 
 
+class VariantType(Enum):
+    SNPS = "snps"  # Length=1
+    INDELS = "indels"  # Length <50
+    MNPS = "mnps"  # Length of ALT same as length of REF
+    OTHER = "other"  # Anything else
+
+    def __str__(self):
+        return self.value
+
+
+def variant_type_set(arg_value: str) -> Set[VariantType]:
+    choices = set(map(lambda v: v.value, VariantType))
+    result = set()
+    for typ in arg_value.split(","):
+        if typ not in choices:
+            raise UserInputError(f"{typ} is not a valid type (try one of {choices})")
+        result.add(VariantType[typ.upper()])
+    assert len(result) > 0
+    return result
+
+
 def list_or_filename(arg_value):
-    if not os.path.isfile(arg_value):
-        parts = arg_value.split(",")
-        return list(map(str.strip, parts))
-    with open(arg_value) as f:
-        return list(map(str.strip, f))
+    parts = arg_value.split(",")
+    if len(parts) == 1:
+        if not os.path.isfile(arg_value):
+            raise UserInputError(f"Cannot access file {arg_value}")
+        with open(arg_value) as f:
+            return list(map(str.strip, f))
+    return list(map(str.strip, parts))
 
 
 def int_list_or_filename(arg_value):
@@ -98,6 +122,33 @@ def add_options(subparser: argparse.ArgumentParser):
         type=float,
         help="Maximum allele frequency to keep. All Mutations with frequency above this value will be dropped",
     )
+    mutation_group.add_argument(
+        "-v",
+        "--types",
+        type=variant_type_set,
+        help="Comma-separated list of variant types to select. Site is selected if any of the ALT alleles is of the type requested. Types are determined by comparing the REF and ALT alleles.",
+    )
+    mutation_group.add_argument(
+        "-A",
+        "--apply-to-sites",
+        action="store_true",
+        help="By default, all filters apply to each variant independently. This flag will cause an entire site to be dropped if any variants are filtered out.",
+    )
+    mutation_group.add_argument(
+        "-m",
+        "--min-alleles",
+        type=int,
+        default=1,
+        help="Only keep sites with at least this many alleles. Counts all REF alleles as 1.",
+    )
+    mutation_group.add_argument(
+        "-M",
+        "--max-alleles",
+        type=int,
+        default=2**32,
+        help="Only keep sites with at most this many alleles. Counts all REF alleles as 1. "
+        "Use '-m 2 -M 2 -v snps' to view only biallelic SNPs.",
+    )
 
 
 def require_unspecified(args, msg, *params):
@@ -116,6 +167,10 @@ def run(args):
             "max_ac",
             "min_af",
             "max_af",
+            "types",
+            "apply_to_sites",
+            "min_alleles",
+            "max_alleles",
         )
 
     if args.individuals:
@@ -160,9 +215,31 @@ def run(args):
                 return False
             if args.max_af is not None and freqs[mut_id] > args.max_af:
                 return False
+            if args.types is not None:
+                ref_len = len(mut.ref_allele)
+                alt_len = len(mut.allele)
+                if ref_len == alt_len:
+                    if ref_len == 1:
+                        my_type = VariantType.SNPS
+                    else:
+                        my_type = VariantType.MNPS
+                elif ref_len < 50 and alt_len < 50:
+                    my_type = VariantType.INDELS
+                else:
+                    my_type = VariantType.OTHER
+                return my_type in args.types
             return True
 
-        grg_save_mut_filter(args.grg_input, args.grg_output, filter_method, brange)
+        kept, dropped = grg_save_mut_filter(
+            args.grg_input,
+            args.grg_output,
+            filter_method,
+            brange,
+            apply_to_sites=args.apply_to_sites,
+            min_variants=args.min_alleles - 1,  # Counting the REF allele
+            max_variants=args.max_alleles - 1,  # Counting the REF allele
+        )
+        print(f"Kept {kept} variants. Dropped {dropped} variants")
 
 
 if __name__ == "__main__":

--- a/grapp/cli/show_cli.py
+++ b/grapp/cli/show_cli.py
@@ -1,6 +1,13 @@
 import argparse
+import numpy
+import pandas
 import pygrgl
+import sys
 from collections import defaultdict
+from grapp.util.simple import (
+    allele_counts,
+    allele_frequencies,
+)
 
 
 def add_options(subparser: argparse.ArgumentParser):
@@ -18,16 +25,35 @@ def add_options(subparser: argparse.ArgumentParser):
         action="store_true",
         help="Show the population information.",
     )
+    whattoshow.add_argument(
+        "-i",
+        "--info",
+        action="store_true",
+        help="Show the high-level GRG information.",
+    )
+    whattoshow.add_argument(
+        "-f",
+        "--frequencies",
+        action="store_true",
+        help="Show the tab-separated allele frequency information.",
+    )
+    whattoshow.add_argument(
+        "-c",
+        "--counts",
+        action="store_true",
+        help="Show the tab-separated allele counts information.",
+    )
 
 
 def run(args):
     grg = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
-    print(f"Mutations: {grg.num_mutations}")
-    print(f"Samples: {grg.num_samples}")
-    print(f"Individuals: {grg.num_individuals}")
-    print(f"Phased? {'Yes' if grg.is_phased else 'No'}")
-    print(f"Nodes: {grg.num_nodes}")
-    print(f"Edges: {grg.num_edges}")
+    if args.info:
+        print(f"Mutations: {grg.num_mutations}")
+        print(f"Samples: {grg.num_samples}")
+        print(f"Individuals: {grg.num_individuals}")
+        print(f"Phased? {'Yes' if grg.is_phased else 'No'}")
+        print(f"Nodes: {grg.num_nodes}")
+        print(f"Edges: {grg.num_edges}")
     if args.individuals:
         if grg.has_individual_ids:
             print("\n".join(map(grg.get_individual_id, range(grg.num_individuals))))
@@ -39,3 +65,29 @@ def run(args):
                 by_pop[grg.get_population_id(sample_id)] += 1
             for p, label in enumerate(pop_labels):
                 print(f"{label}: {by_pop[p]}/{grg.num_samples} haplotypes")
+    if args.frequencies:
+        freq = allele_frequencies(grg, adjust_missing=True)
+        muts = list(map(lambda m: grg.get_mutation_by_id(m), range(grg.num_mutations)))
+        df = pandas.DataFrame(
+            {
+                "Position": numpy.array(map(lambda m: m.position, muts)),
+                "REF": numpy.array(map(lambda m: m.ref_allele, muts)),
+                "ALT": numpy.array(map(lambda m: m.allele, muts)),
+                "Frequency": freq,
+            }
+        )
+        df.to_csv(sys.stdout, sep="\t", index=False)
+    if args.counts:
+        acount, amiss = allele_counts(grg, return_missing=True)
+        muts = list(map(lambda m: grg.get_mutation_by_id(m), range(grg.num_mutations)))
+        df = pandas.DataFrame(
+            {
+                "Position": numpy.array(map(lambda m: m.position, muts)),
+                "REF": numpy.array(map(lambda m: m.ref_allele, muts)),
+                "ALT": numpy.array(map(lambda m: m.allele, muts)),
+                "ALT Count": acount,
+                "Missing Count": amiss,
+                "Total": grg.num_samples,
+            }
+        )
+        df.to_csv(sys.stdout, sep="\t", index=False)

--- a/grapp/util/filter.py
+++ b/grapp/util/filter.py
@@ -4,6 +4,7 @@ Functions for filtering data out of a GRG to create a new, smaller GRG.
 
 from multiprocessing import Pool
 from typing import List, Tuple, Optional, Union, Callable
+from collections import defaultdict
 import os
 import pygrgl
 
@@ -199,6 +200,9 @@ def grg_save_mut_filter(
     out_filename: str,
     mut_filter: Callable[[pygrgl.GRG, int], bool],
     bp_range: Tuple[int, int] = (0, 0),
+    apply_to_sites: bool = False,
+    min_variants: int = 0,
+    max_variants: int = 2**32,
 ):
     """
     Given a GRG filename or object, save a new GRG that contains only the Mutations selected
@@ -211,13 +215,42 @@ def grg_save_mut_filter(
     :param mut_filter: Callback (function) that takes a MutationID (int) as input and returns
         true if that mutation should be kept.
     :type mut_filter: Callable[[pygrgl.GRG, int], bool]
+    :param bp_range: The range to associate with the GRG, as metadata. DOES NOT IMPACT THE
+        FILTERING AT ALL.
+    :type bp_range: Tuple[int, int]
+    :param apply_to_sites: By default, the filter applies to each variant independently. This
+        flag will cause an entire site to be dropped if any variants are filtered out.
+    :type apply_to_sites: bool
+    :param min_variants: Any site with fewer variants than this will be dropped.
+    :type min_variants: int
+    :param max_variants: Any site with more variants than this will be dropped.
+    :type max_variants: int
+    :return: Tuple (mutations kept, mutations dropped)
+    :rtype: Tuple[int, int]
     """
     if isinstance(grg_or_filename, str):
         grg = pygrgl.load_immutable_grg(grg_or_filename, load_up_edges=False)
     else:
         grg = grg_or_filename
 
-    seeds = list(filter(lambda m: mut_filter(grg, m), range(grg.num_mutations)))
+    site2muts = defaultdict(list)
+    for m in range(grg.num_mutations):
+        mut = grg.get_mutation_by_id(m)
+        site2muts[mut.position].append(m)
+
+    seeds = []
+    for _, muts in sorted(site2muts.items()):
+        if len(muts) < min_variants or len(muts) > max_variants:
+            continue
+        keep_muts = []
+        for m in muts:
+            if mut_filter(grg, m):
+                keep_muts.append(m)
+        if apply_to_sites:
+            if len(keep_muts) == len(muts):
+                seeds.extend(keep_muts)
+        else:
+            seeds.extend(keep_muts)
     if not seeds:
         raise UserInputError(
             "No Mutations found matching range; cannot filter to an empty GRG."
@@ -229,6 +262,7 @@ def grg_save_mut_filter(
         seeds,
         bp_range=bp_range,
     )
+    return (len(seeds), grg.num_mutations - len(seeds))
 
 
 def multi_grg_save_mut_filter(


### PR DESCRIPTION
Emulate bcftools with -m/-M and -v (--types). This lets us filter to bi-allelic SNPs, e.g.

Add `grapp show -c` and `grapp show -a` for allele counts and allele frequencies, respectively.

Also, added a cheatsheet for commands.