### PR TITLE
Change mask_samples --> sample_filter

### DIFF
--- a/grapp/assoc/__init__.py
+++ b/grapp/assoc/__init__.py
@@ -1,7 +1,7 @@
 from grapp.linalg.ops_scipy import SciPyStdXOperator, SciPyXOperator
 from grapp.util.simple import allele_counts, _GenotypeDist
 from scipy.stats import t as t_distribution
-from typing import List
+from typing import List, Optional, Union
 import itertools
 import math
 import numpy
@@ -109,7 +109,7 @@ def _computeDiagXTX(
     n_j: numpy.typing.NDArray,
     afreq_haploid: numpy.typing.NDArray,
     standardize: bool,
-    mask_indivs: List[int] = [],
+    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
 ):
     # diag(X^T @ X): for any standardized matrix with N rows, the diagonal will just be N
     if standardize:
@@ -128,8 +128,8 @@ def _computeDiagXTX(
             # to perform an adjustment. It was calculated for true_n samples, when we only have n_j
             # samples after masking. This is equivalent to using X^T*X to compute the sample variance
             # and then computing n_j*variance.
-            if mask_indivs:
-                true_n = n_j + len(mask_indivs)
+            if sample_filter is not None:
+                true_n = n_j + (grg.num_individuals - len(sample_filter))
                 XX = (XX * n_j) / true_n
         else:
             assert dist == _GenotypeDist.BINOMIAL.value
@@ -166,21 +166,24 @@ def linear_assoc_no_covar(
     PLOIDY = 2
     assert grg.ploidy == PLOIDY, "GWAS is only supported on diploid individuals"
     assert _GenotypeDist.is_valid(dist), "Invalid dist= value provided"
-    y_missing = numpy.isnan(Y)
-    assert not numpy.all(y_missing), "Error: phenotype is all NaN (missing)"
-    missing_indivs = numpy.flatnonzero(y_missing).tolist()
-    missing_samples = list(
-        itertools.chain.from_iterable(map(lambda i: (2 * i, 2 * i + 1), missing_indivs))
+    y_miss = numpy.isnan(Y)
+    assert not numpy.all(y_miss), "Error: phenotype is all NaN (missing)"
+    non_missing_indivs = numpy.flatnonzero(~y_miss).tolist()
+    non_missing_samples = list(
+        itertools.chain.from_iterable(
+            map(lambda i: (2 * i, 2 * i + 1), non_missing_indivs)
+        )
     )
-    # Zero out the missing individuals for all future operations
-    if missing_indivs:
-        Y = Y.copy()
-        Y[missing_indivs] = 0
+    # Remove the missing individuals from the Y matrix.
+    if any(y_miss):
+        Y = Y[non_missing_indivs]
 
     acount, miss_count = allele_counts(
-        grg, return_missing=True, mask_samples=missing_samples
+        grg,
+        return_missing=True,
+        sample_filter=non_missing_samples,
     )
-    n = grg.num_individuals - len(missing_indivs)
+    n = len(non_missing_indivs)
     n_j = n - (miss_count / PLOIDY)
     assert numpy.all(n_j >= 0.0)
     afreq_diploid = _div_or_default(acount, n_j, 0.0)
@@ -191,7 +194,7 @@ def linear_assoc_no_covar(
             pygrgl.TraversalDirection.UP,
             afreq_haploid,
             haploid=False,
-            mask_samples=missing_indivs,
+            sample_filter=non_missing_indivs,
         )
         x_mean = numpy.zeros(afreq_diploid.shape)
         nx_mean = numpy.zeros(acount.shape)
@@ -201,7 +204,7 @@ def linear_assoc_no_covar(
             pygrgl.TraversalDirection.UP,
             haploid=False,
             miss_values=afreq_haploid,
-            mask_samples=missing_indivs,
+            sample_filter=non_missing_indivs,
         )
         x_mean = afreq_diploid  # 2*f_i
         nx_mean = acount  # 2*n*f_i
@@ -211,7 +214,13 @@ def linear_assoc_no_covar(
     total_pheno = Y.sum()
     nodeXY = mut_XY_count - n_j * x_mean * (total_pheno / n)
     XX = _computeDiagXTX(
-        grg, dist, acount, n_j, afreq_haploid, standardize, mask_indivs=missing_indivs
+        grg,
+        dist,
+        acount,
+        n_j,
+        afreq_haploid,
+        standardize,
+        sample_filter=non_missing_indivs,
     )
     nodeXX = XX - nx_mean * x_mean
     beta = _div_or_default(nodeXY, nodeXX, math.nan)
@@ -308,6 +317,19 @@ def linear_assoc_covar(
     assert method in ("QR", "regress"), 'Invalid "method" parameter'
     assert _GenotypeDist.is_valid(dist), "Invalid dist= value provided"
 
+    y_miss = numpy.isnan(Y)
+    assert not numpy.all(y_miss), "Error: phenotype is all NaN (missing)"
+    non_missing_indivs = numpy.flatnonzero(~y_miss).tolist()
+    non_missing_samples = list(
+        itertools.chain.from_iterable(
+            map(lambda i: (2 * i, 2 * i + 1), non_missing_indivs)
+        )
+    )
+    # Remove the missing individuals from the Y and C matrices.
+    if any(y_miss):
+        Y = Y[non_missing_indivs]
+        C = C[non_missing_indivs, :]
+
     if method == "regress":
         model = sklearn.linear_model.LinearRegression()
         regression = model.fit(C, Y)
@@ -319,17 +341,6 @@ def linear_assoc_covar(
             standardize=standardize,
         )
 
-    y_missing = numpy.isnan(Y)
-    assert not numpy.all(y_missing), "Error: phenotype is all NaN (missing)"
-    missing_indivs = numpy.flatnonzero(y_missing).tolist()
-    missing_samples = list(
-        itertools.chain.from_iterable(map(lambda i: (2 * i, 2 * i + 1), missing_indivs))
-    )
-    # Zero out the missing individuals for all future operations
-    if missing_indivs:
-        Y = Y.copy()
-        Y[missing_indivs] = 0
-
     # QR decompose the covariate matrix after adding an intercept column.
     C_intercept = numpy.hstack([numpy.ones((C.shape[0], 1)), C])
     Q, R = numpy.linalg.qr(C_intercept)
@@ -340,9 +351,9 @@ def linear_assoc_covar(
         Yadj = (Yadj - numpy.mean(Yadj, axis=0)) / numpy.std(Yadj, axis=0)
 
     acount, miss_count = allele_counts(
-        grg, return_missing=True, mask_samples=missing_samples
+        grg, return_missing=True, sample_filter=non_missing_samples
     )
-    n = grg.num_individuals - len(missing_indivs)
+    n = len(non_missing_indivs)
     n_j = n - (miss_count / PLOIDY)
     assert numpy.all(n_j >= 0.0)
     afreq_diploid = _div_or_default(acount, n_j, 0.0)
@@ -356,7 +367,7 @@ def linear_assoc_covar(
             pygrgl.TraversalDirection.UP,
             afreq_haploid,
             haploid=False,
-            mask_samples=missing_indivs,
+            sample_filter=non_missing_indivs,
         )
     else:
         X_op = SciPyXOperator(
@@ -364,7 +375,7 @@ def linear_assoc_covar(
             pygrgl.TraversalDirection.UP,
             haploid=False,
             miss_values=afreq_haploid,
-            mask_samples=missing_indivs,
+            sample_filter=non_missing_indivs,
         )
 
     # G^TQ
@@ -375,7 +386,13 @@ def linear_assoc_covar(
 
     # Xadj^TXadj
     XX = _computeDiagXTX(
-        grg, dist, acount, n_j, afreq_haploid, standardize, mask_indivs=missing_indivs
+        grg,
+        dist,
+        acount,
+        n_j,
+        afreq_haploid,
+        standardize,
+        sample_filter=non_missing_indivs,
     )
     xadjTxadj = XX - diagonal
 

--- a/grapp/cli/pheno_cli.py
+++ b/grapp/cli/pheno_cli.py
@@ -45,7 +45,6 @@ def add_options(subparser):
 
 def run(args):
     base = os.path.basename(args.grg_input)
-    effect_path = f"{base}.effects.par"
     output_path = f"{base}.phen"
     grg = pygrgl.load_immutable_grg(args.grg_input, load_up_edges=False)
     phenotypes = sim_phenotypes(

--- a/grapp/linalg/ops_scipy.py
+++ b/grapp/linalg/ops_scipy.py
@@ -27,6 +27,72 @@ def _transpose_shape(shape: Tuple[int, int]) -> Tuple[int, int]:
     return (shape[1], shape[0])
 
 
+class GRGOpFilter:
+    def __init__(
+        self,
+        grg: pygrgl.GRG,
+        haploid: bool,
+        mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]],
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]],
+    ):
+        if mutation_filter is not None:
+            if isinstance(mutation_filter, numpy.ndarray):
+                mutation_filter = mutation_filter.tolist()
+            assert len(set(mutation_filter)) == len(
+                mutation_filter
+            ), "Duplicate IDs in mutation_filter"
+        self.mutation_filter = mutation_filter
+        if sample_filter is not None:
+            if isinstance(sample_filter, numpy.ndarray):
+                sample_filter = sample_filter.tolist()
+            assert len(set(sample_filter)) == len(
+                sample_filter
+            ), "Duplicate IDs in sample_filter"
+        self.sample_filter = sample_filter
+
+        sample_count = grg.num_samples if haploid else grg.num_individuals
+        self.grg_shape = (sample_count, grg.num_mutations)
+        self.shape = (
+            self.grg_shape[0] if sample_filter is None else len(sample_filter),
+            self.grg_shape[1] if mutation_filter is None else len(mutation_filter),
+        )
+        self.is_filtering = (
+            self.sample_filter is not None or self.mutation_filter is not None
+        )
+
+    def prep_input(
+        self, input_matrix: numpy.typing.NDArray, mult_dir: TraversalDirection
+    ):
+        if mult_dir == _DOWN:
+            if self.mutation_filter is not None:
+                new_matrix = numpy.zeros(
+                    (input_matrix.shape[0], self.grg_shape[1]), dtype=input_matrix.dtype
+                )
+                new_matrix[:, self.mutation_filter] = input_matrix  # type: ignore
+                return new_matrix
+        else:
+            assert mult_dir == _UP
+            if self.sample_filter is not None:
+                new_matrix = numpy.zeros(
+                    (input_matrix.shape[0], self.grg_shape[0]), dtype=input_matrix.dtype
+                )
+                new_matrix[:, self.sample_filter] = input_matrix  # type: ignore
+                return new_matrix
+        return input_matrix
+
+    def adjust_output(
+        self, output_matrix: numpy.typing.NDArray, mult_dir: TraversalDirection
+    ):
+        if mult_dir == _UP:
+            if self.mutation_filter is not None:
+                return output_matrix[:, self.mutation_filter]
+        else:
+            assert mult_dir == _DOWN
+            if self.sample_filter is not None:
+                return output_matrix[:, self.sample_filter]
+        return output_matrix
+
+
 class SciPyXOperator(LinearOperator):
     """
     A scipy.sparse.linalg.LinearOperator on the genotype matrix represented by the GRG, which allows for
@@ -50,12 +116,11 @@ class SciPyXOperator(LinearOperator):
         (e.g., missingness-adjusted allele frequency) is provided. Default: None.
     :type miss_values: Optional[numpy.typing.NDArray]
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
-    :param mask_samples: Ignore any contribution from the samples listed in this array (e.g., pretend
-        they don't exist in the GRG). This does not affect the dimensions of the multiplication operations.
-        If haploid=True, these should be sample node IDs. Otherwise, they should be individual IDs.
-    :type mask_samples: Union[List[int], numpy.typing.NDArray]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     """
 
     def __init__(
@@ -66,28 +131,17 @@ class SciPyXOperator(LinearOperator):
         haploid: bool = False,
         miss_values: Optional[numpy.typing.NDArray] = None,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
-        mask_samples: Union[List[int], numpy.typing.NDArray] = [],
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
     ):
-        if isinstance(mutation_filter, numpy.ndarray):
-            mutation_filter = mutation_filter.tolist()
+        self.filter = GRGOpFilter(grg, haploid, mutation_filter, sample_filter)
         self.haploid = haploid
         self.grg = grg
-        self.sample_count = grg.num_samples if haploid else grg.num_individuals
         self.direction = direction
-        self.mutation_filter = mutation_filter
-        if isinstance(mask_samples, numpy.ndarray):
-            mask_samples = mask_samples.tolist()
-        self.mask_samples = mask_samples
-        self.grg_shape = (self.sample_count, grg.num_mutations)
-        shape = (
-            self.grg_shape
-            if mutation_filter is None
-            else (self.grg_shape[0], len(self.mutation_filter))  # type: ignore
-        )
         assert (
             miss_values is None or miss_values.ndim == 1
         ), 'If "miss_values" is provided, it must be a vector'
         self.miss_values = miss_values
+        shape = self.filter.shape
         if self.direction == _DOWN:
             shape = _transpose_shape(shape)
         super().__init__(dtype=dtype, shape=shape)
@@ -96,21 +150,7 @@ class SciPyXOperator(LinearOperator):
         self, other_matrix: numpy.typing.NDArray, mult_dir: TraversalDirection
     ):
         kwargs = {}
-        if self.mutation_filter is not None and mult_dir == _DOWN:
-            A = numpy.zeros(
-                (other_matrix.shape[1], self.grg_shape[1]), dtype=other_matrix.dtype
-            )
-            A[:, self.mutation_filter] = other_matrix.T  # type: ignore
-        else:
-            A = other_matrix.T
-
-        # Notice: if this operator is used by another operator that modifies A (e.g., the standardized
-        # operators) this still works, because we 0 the value out right before the multiplication, treating
-        # these samples like they truly do not exist in the graph.
-        if mult_dir == _UP and self.mask_samples:
-            if A is other_matrix.T:
-                A = other_matrix.T.copy()
-            A[:, self.mask_samples] = 0
+        A = self.filter.prep_input(other_matrix.T, mult_dir)
 
         # When doing the multiplication AX^T (DOWN), we need to initialize the missingness node
         # data values ("miss") with the input matrix * the missingness mean values per mutation.
@@ -135,10 +175,7 @@ class SciPyXOperator(LinearOperator):
         if mult_dir == _UP and use_M:
             result += M * self.miss_values
 
-        Y = result
-        if self.mutation_filter is not None and mult_dir == _UP:
-            Y = Y[:, self.mutation_filter]  # type: ignore
-        return Y.T
+        return self.filter.adjust_output(result, mult_dir).T
 
     def _matmat(self, other_matrix):
         return self._matmat_helper(other_matrix, _flip_dir(self.direction))
@@ -178,8 +215,11 @@ class SciPyXTXOperator(LinearOperator):
         (e.g., missingness-adjusted allele frequency) is provided. Default: None.
     :type miss_values: Optional[numpy.typing.NDArray]
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     """
 
     def __init__(
@@ -189,14 +229,8 @@ class SciPyXTXOperator(LinearOperator):
         haploid: bool = False,
         miss_values: Optional[numpy.typing.NDArray] = None,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
     ):
-        if isinstance(mutation_filter, numpy.ndarray):
-            mutation_filter = mutation_filter.tolist()
-        num_muts = (
-            grg.num_mutations if mutation_filter is None else len(mutation_filter)
-        )
-        xtx_shape = (num_muts, num_muts)
-        super().__init__(dtype=dtype, shape=xtx_shape)
         self.x_op = SciPyXOperator(
             grg,
             _UP,
@@ -204,7 +238,10 @@ class SciPyXTXOperator(LinearOperator):
             haploid=haploid,
             miss_values=miss_values,
             mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
         )
+        xtx_shape = (self.x_op.shape[1], self.x_op.shape[1])
+        super().__init__(dtype=dtype, shape=xtx_shape)
 
     def _matmat(self, other_matrix):
         D = self.x_op._matmat(other_matrix)
@@ -244,8 +281,11 @@ class SciPyXXTOperator(LinearOperator):
         (e.g., missingness-adjusted allele frequency) is provided. Default: None.
     :type miss_values: Optional[numpy.typing.NDArray]
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     """
 
     def __init__(
@@ -255,12 +295,8 @@ class SciPyXXTOperator(LinearOperator):
         haploid: bool = False,
         miss_values: Optional[numpy.typing.NDArray] = None,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
     ):
-        if isinstance(mutation_filter, numpy.ndarray):
-            mutation_filter = mutation_filter.tolist()
-        sample_count = grg.num_samples if haploid else grg.num_individuals
-        xxt_shape = (sample_count, sample_count)
-        super().__init__(dtype=dtype, shape=xxt_shape)
         self.x_op = SciPyXOperator(
             grg,
             _UP,
@@ -268,7 +304,10 @@ class SciPyXXTOperator(LinearOperator):
             haploid=haploid,
             miss_values=miss_values,
             mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
         )
+        xxt_shape = (self.x_op.shape[0], self.x_op.shape[0])
+        super().__init__(dtype=dtype, shape=xxt_shape)
 
     def _matmat(self, other_matrix):
         D = self.x_op._rmatmat(other_matrix)
@@ -303,11 +342,8 @@ class _SciPyStandardizedOperator(LinearOperator):
         self.grg = grg
         self.freqs = freqs
         self.mult_const = 1 if self.haploid else grg.ploidy
-        self.sample_count = grg.num_samples if haploid else grg.num_individuals
 
-        # TODO: there might be other normalization approachs besides this. For example, FlashPCA2 has different
-        # options for what to use (this is the P-trial binomial, where P is either ploidy or 1 if haploid is set
-        # to True).
+        # TODO: we also want to support sample-based variance calculation, using init=xtx
         raw = self.mult_const * self.freqs * (1.0 - self.freqs)
 
         # Two versions of sigma, the second flips 0 values (which means the frequency was
@@ -346,12 +382,11 @@ class SciPyStdXOperator(_SciPyStandardizedOperator):
         genotype matrix. Default: False.
     :type haploid: bool
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Only keep mutations with IDs in mutation_filter. Default: empty filter.
+        mutation_filter) instead of NxM. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
-    :param mask_samples: Ignore any contribution from the samples listed in this array (e.g., pretend
-        they don't exist in the GRG). This does not affect the dimensions of the multiplication operations.
-        If haploid=True, these should be sample node IDs. Otherwise, they should be individual IDs.
-    :type mask_samples: Union[List[int], numpy.typing.NDArray]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     """
 
     def __init__(
@@ -362,46 +397,23 @@ class SciPyStdXOperator(_SciPyStandardizedOperator):
         dtype: TypeAlias = numpy.float64,
         haploid: bool = False,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
-        mask_samples: Union[List[int], numpy.typing.NDArray] = [],
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
     ):
-        if isinstance(mutation_filter, numpy.ndarray):
-            mutation_filter = mutation_filter.tolist()
+        self.filter = GRGOpFilter(grg, haploid, mutation_filter, sample_filter)
         self.direction = direction
-        self.sample_count = grg.num_samples if haploid else grg.num_individuals
-        self.mutation_filter = mutation_filter
-        if isinstance(mask_samples, numpy.ndarray):
-            mask_samples = mask_samples.tolist()
-        self.mask_samples = mask_samples
-        self.grg_shape = (self.sample_count, grg.num_mutations)
-        shape = (
-            self.grg_shape
-            if mutation_filter is None
-            else (self.grg_shape[0], len(self.mutation_filter))  # type: ignore
-        )
+        shape = self.filter.shape
         if self.direction == _DOWN:
             shape = _transpose_shape(shape)
         super().__init__(grg, freqs, shape, dtype=dtype, haploid=haploid)
 
     def _matmat_direction(self, other_matrix, direction):
         mult_dir = _flip_dir(direction)
-
-        def expandm(matrix):
-            if self.mutation_filter is not None and mult_dir == _DOWN:
-                result = numpy.zeros(
-                    (matrix.shape[0], self.grg_shape[1]), dtype=matrix.dtype
-                )
-                result[:, self.mutation_filter] = matrix  # type: ignore
-                return result
-            return matrix
-
-        def contractm(matrix):
-            if self.mutation_filter is not None and mult_dir == _UP:
-                return matrix[:, self.mutation_filter]  # type: ignore
-            return matrix
-
         with numpy.errstate(divide="raise"):
             if direction == _UP:
-                vS = expandm(other_matrix.T) / self.sigma_corrected
+                vS = (
+                    self.filter.prep_input(other_matrix.T, mult_dir)
+                    / self.sigma_corrected
+                )
                 XvS = pygrgl.matmul(
                     self.grg,
                     vS,
@@ -411,13 +423,10 @@ class SciPyStdXOperator(_SciPyStandardizedOperator):
                 consts = numpy.array(
                     [numpy.sum(self.mult_const * self.freqs * vS, axis=1)]
                 ).T
-                return contractm(XvS - consts).T
+                return self.filter.adjust_output(XvS - consts, mult_dir).T
             else:
                 assert direction == _DOWN
-                m = expandm(other_matrix.T)
-                if self.mask_samples:
-                    m = m.copy() if m is other_matrix.T else m
-                    m[:, self.mask_samples] = 0
+                m = self.filter.prep_input(other_matrix.T, mult_dir)
                 SXv = (
                     pygrgl.matmul(
                         self.grg,
@@ -431,7 +440,7 @@ class SciPyStdXOperator(_SciPyStandardizedOperator):
                 sub_const2 = (
                     self.mult_const * self.freqs / self.sigma_corrected
                 ) * col_const
-                return contractm(SXv - sub_const2).T
+                return self.filter.adjust_output(SXv - sub_const2, mult_dir).T
 
     def _matmat(self, other_matrix):
         return self._matmat_direction(other_matrix, self.direction)
@@ -477,8 +486,11 @@ class SciPyStdXTXOperator(LinearOperator):
         genotype matrix. Default: False.
     :type haploid: bool
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     """
 
     def __init__(
@@ -488,14 +500,9 @@ class SciPyStdXTXOperator(LinearOperator):
         dtype: TypeAlias = numpy.float64,
         haploid: bool = False,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
     ):
-        if isinstance(mutation_filter, numpy.ndarray):
-            mutation_filter = mutation_filter.tolist()
-        num_muts = (
-            grg.num_mutations if mutation_filter is None else len(mutation_filter)
-        )
-        xtx_shape = (num_muts, num_muts)
-        super().__init__(dtype=dtype, shape=xtx_shape)
+        self.filter = GRGOpFilter(grg, haploid, mutation_filter, sample_filter)
         self.std_x_op = SciPyStdXOperator(
             grg,
             _UP,
@@ -503,7 +510,10 @@ class SciPyStdXTXOperator(LinearOperator):
             haploid=haploid,
             dtype=dtype,
             mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
         )
+        xtx_shape = (self.std_x_op.shape[1], self.std_x_op.shape[1])
+        super().__init__(dtype=dtype, shape=xtx_shape)
 
     def _matmat(self, other_matrix):
         D = self.std_x_op._matmat(other_matrix)
@@ -545,6 +555,12 @@ class SciPyStdXXTOperator(LinearOperator):
     :param haploid: Perform calculations on the {0, 1} haploid genotype matrix, instead of the {0, ..., grg.ploidy}
         genotype matrix. Default: False.
     :type haploid: bool
+    :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
+        mutation_filter) instead of NxM. Default: no filter.
+    :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     """
 
     def __init__(
@@ -553,11 +569,20 @@ class SciPyStdXXTOperator(LinearOperator):
         freqs: numpy.typing.NDArray,
         dtype: TypeAlias = numpy.float64,
         haploid: bool = False,
+        mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
     ):
-        self.sample_count = grg.num_samples if haploid else grg.num_individuals
-        xxt_shape = (self.sample_count, self.sample_count)
+        self.std_x_op = SciPyStdXOperator(
+            grg,
+            _UP,
+            freqs,
+            haploid=haploid,
+            dtype=dtype,
+            mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
+        )
+        xxt_shape = (self.std_x_op.shape[0], self.std_x_op.shape[0])
         super().__init__(dtype=dtype, shape=xxt_shape)
-        self.std_x_op = SciPyStdXOperator(grg, _UP, freqs, haploid=haploid, dtype=dtype)
 
     def _matmat(self, other_matrix):
         D = self.std_x_op._rmatmat(other_matrix)
@@ -599,8 +624,16 @@ class MultiSciPyXOperator(LinearOperator):
         (e.g., missingness-adjusted allele frequency) is provided. Default: None.
     :type miss_values: Optional[numpy.typing.NDArray]
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Here the mutation filter follows the same numbering as the
+        input/output matrices: for example, if grgs=[grg1, grg2] then indexes 0...(grg1.num_mutations-1)
+        will be for grg1, and grg1.num_mutations...(grg1.num_mutations+grg2.num_mutations-1) will be the
+        mutations for grg2. Then if you have a mutation_filter containing the number ``grg1.num_mutations + 4``
+        it means it will keep grg2's mutation with ID ``4``. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Since all GRGs have the same samples, this behavior is the
+        same as the non-Multi operators. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     :param threads: Number of threads for performing the multiplication. Each GRG can be done in
         parallel.
     :type threads: int
@@ -614,32 +647,30 @@ class MultiSciPyXOperator(LinearOperator):
         haploid: bool = False,
         miss_values: Optional[numpy.typing.NDArray] = None,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
         threads: int = 1,
     ):
-        if isinstance(mutation_filter, numpy.ndarray):
-            mutation_filter = mutation_filter.tolist()
         assert len(grgs) >= 1, "Must provide at least one GRG"
         self.direction = direction
         self.num_mutations = sum([g.num_mutations for g in grgs])
-        self.mutation_filter = mutation_filter
-        if self.mutation_filter is not None:
-            assert len(self.mutation_filter) <= self.num_mutations
-            self.num_mutations = len(self.mutation_filter)
+        if mutation_filter is not None:
+            assert len(mutation_filter) <= self.num_mutations
+            self.num_mutations = len(mutation_filter)
         self.operators = []
-        num_samples = grgs[0].num_samples
-        num_indivs = grgs[0].num_individuals
         prev_miss_start = 0
         prev_max_mut = 0
         for g in grgs:
-            assert g.num_samples == num_samples, "All GRGs must use the same samples"
-            if self.mutation_filter is not None:
+            assert (
+                g.num_samples == grgs[0].num_samples
+            ), "All GRGs must use the same samples"
+            if mutation_filter is not None:
                 grg_mut_filt = list(
                     map(
                         lambda m: m - prev_max_mut,
                         filter(
                             lambda m: m >= prev_max_mut
                             and m < prev_max_mut + g.num_mutations,
-                            self.mutation_filter,
+                            mutation_filter,
                         ),
                     )
                 )
@@ -667,16 +698,25 @@ class MultiSciPyXOperator(LinearOperator):
                         haploid=haploid,
                         miss_values=grg_miss_values,
                         mutation_filter=grg_mut_filt,
+                        sample_filter=sample_filter,
                     )
                 )
             prev_max_mut += g.num_mutations
         # Should we concatenate the result for _matmat, or add them together?
         self.concat = self.direction == pygrgl.TraversalDirection.DOWN
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
-        sample_count = num_samples if haploid else num_indivs
-        shape = (sample_count, self.num_mutations)
-        if direction == _DOWN:
-            shape = _transpose_shape(shape)
+        shape = (self.operators[0].shape[0], self.num_mutations)
+        if direction == _UP:
+            shape = (
+                self.operators[0].shape[0],
+                sum(map(lambda op: op.shape[1], self.operators)),
+            )
+        else:
+            assert direction == _DOWN
+            shape = (
+                sum(map(lambda op: op.shape[0], self.operators)),
+                self.operators[0].shape[1],
+            )
         super().__init__(dtype=dtype, shape=shape)
 
     def _matmat_helper(self, other_matrix, direction, op_method):
@@ -743,8 +783,16 @@ class MultiSciPyXTXOperator(LinearOperator):
         (e.g., missingness-adjusted allele frequency) is provided. Default: None.
     :type miss_values: Optional[numpy.typing.NDArray]
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Here the mutation filter follows the same numbering as the
+        input/output matrices: for example, if grgs=[grg1, grg2] then indexes 0...(grg1.num_mutations-1)
+        will be for grg1, and grg1.num_mutations...(grg1.num_mutations+grg2.num_mutations-1) will be the
+        mutations for grg2. Then if you have a mutation_filter containing the number ``grg1.num_mutations + 4``
+        it means it will keep grg2's mutation with ID ``4``. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Since all GRGs have the same samples, this behavior is the
+        same as the non-Multi operators. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     :param threads: Number of threads for performing the multiplication. Each GRG can be done in
         parallel.
     :type threads: int
@@ -757,6 +805,7 @@ class MultiSciPyXTXOperator(LinearOperator):
         haploid: bool = False,
         miss_values: Optional[numpy.typing.NDArray] = None,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
         threads: int = 1,
     ):
         self.x_op = MultiSciPyXOperator(
@@ -766,9 +815,10 @@ class MultiSciPyXTXOperator(LinearOperator):
             haploid=haploid,
             miss_values=miss_values,
             mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
             threads=threads,
         )
-        xtx_shape = (self.x_op.num_mutations, self.x_op.num_mutations)
+        xtx_shape = (self.x_op.shape[1], self.x_op.shape[1])
         super().__init__(dtype=dtype, shape=xtx_shape)
 
     def _matmat(self, other_matrix):
@@ -807,8 +857,16 @@ class MultiSciPyStdXOperator(LinearOperator):
         genotype matrix. Default: False.
     :type haploid: bool
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Here the mutation filter follows the same numbering as the
+        input/output matrices: for example, if grgs=[grg1, grg2] then indexes 0...(grg1.num_mutations-1)
+        will be for grg1, and grg1.num_mutations...(grg1.num_mutations+grg2.num_mutations-1) will be the
+        mutations for grg2. Then if you have a mutation_filter containing the number ``grg1.num_mutations + 4``
+        it means it will keep grg2's mutation with ID ``4``. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Since all GRGs have the same samples, this behavior is the
+        same as the non-Multi operators. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     :param threads: Number of threads for performing the multiplication. Each GRG can be done in
         parallel.
     :type threads: int
@@ -822,32 +880,30 @@ class MultiSciPyStdXOperator(LinearOperator):
         dtype: TypeAlias = numpy.float64,
         haploid: bool = False,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
         threads: int = 1,
     ):
-        if isinstance(mutation_filter, numpy.ndarray):
-            mutation_filter = mutation_filter.tolist()
         assert len(grgs) >= 1, "Must provide at least one GRG"
         assert len(grgs) == len(freqs), "Must provide allele frequencies for every GRG"
         self.direction = direction
         self.num_mutations = sum([g.num_mutations for g in grgs])
         num_samples = grgs[0].num_samples
         num_indivs = grgs[0].num_individuals
-        self.mutation_filter = mutation_filter
         if mutation_filter is not None:
-            assert len(self.mutation_filter) <= self.num_mutations  # type: ignore
-            self.num_mutations = len(self.mutation_filter)  # type: ignore
+            assert len(mutation_filter) <= self.num_mutations  # type: ignore
+            self.num_mutations = len(mutation_filter)  # type: ignore
         prev_max_mut = 0
         self.operators = []
         for g, f in zip(grgs, freqs):
             assert g.num_samples == num_samples, "All GRGs must use the same samples"
-            if self.mutation_filter is not None:
+            if mutation_filter is not None:
                 grg_mut_filt = list(
                     map(
                         lambda m: m - prev_max_mut,
                         filter(
                             lambda m: m >= prev_max_mut
                             and m < prev_max_mut + g.num_mutations,
-                            self.mutation_filter,
+                            mutation_filter,
                         ),
                     )
                 )
@@ -865,6 +921,7 @@ class MultiSciPyStdXOperator(LinearOperator):
                         dtype,
                         haploid=haploid,
                         mutation_filter=grg_mut_filt,
+                        sample_filter=sample_filter,
                     )
                 )
             prev_max_mut += g.num_mutations
@@ -939,8 +996,16 @@ class MultiSciPyStdXTXOperator(LinearOperator):
         genotype matrix. Default: False.
     :type haploid: bool
     :param mutation_filter: Changes the dimensions of :math:`X` to be NxP (where P is the length of
-        mutation_filter) instead of NxM. Default: empty filter.
+        mutation_filter) instead of NxM. Here the mutation filter follows the same numbering as the
+        input/output matrices: for example, if grgs=[grg1, grg2] then indexes 0...(grg1.num_mutations-1)
+        will be for grg1, and grg1.num_mutations...(grg1.num_mutations+grg2.num_mutations-1) will be the
+        mutations for grg2. Then if you have a mutation_filter containing the number ``grg1.num_mutations + 4``
+        it means it will keep grg2's mutation with ID ``4``. Default: no filter.
     :type mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :param sample_filter: Changes the dimensions of :math:`X` to be QxM (where Q is the length of
+        sample_filter) instead of NxM. Since all GRGs have the same samples, this behavior is the
+        same as the non-Multi operators. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     :param threads: Number of threads for performing the multiplication. Each GRG can be done in
         parallel.
     :type threads: int
@@ -953,6 +1018,7 @@ class MultiSciPyStdXTXOperator(LinearOperator):
         dtype: TypeAlias = numpy.float64,
         haploid: bool = False,
         mutation_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
         threads: int = 1,
     ):
         self.std_x_op = MultiSciPyStdXOperator(
@@ -962,9 +1028,10 @@ class MultiSciPyStdXTXOperator(LinearOperator):
             haploid=haploid,
             dtype=dtype,
             mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
             threads=threads,
         )
-        xtx_shape = (self.std_x_op.num_mutations, self.std_x_op.num_mutations)
+        xtx_shape = (self.std_x_op.shape[1], self.std_x_op.shape[1])
         super().__init__(dtype=dtype, shape=xtx_shape)
 
     def _matmat(self, other_matrix):

--- a/grapp/util/simple.py
+++ b/grapp/util/simple.py
@@ -3,7 +3,7 @@ Simple utility functions.
 """
 
 from enum import Enum
-from typing import Union, Tuple, List
+from typing import Union, Tuple, List, Optional
 import pygrgl
 import numpy
 
@@ -37,7 +37,7 @@ def _div_or_default(a, b, d):
 def allele_counts(
     grg: pygrgl.GRG,
     return_missing: bool = False,
-    mask_samples: Union[List[int], numpy.typing.NDArray] = [],
+    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
 ) -> Union[numpy.typing.NDArray, Tuple[numpy.typing.NDArray, numpy.typing.NDArray]]:
     """
     Get the allele counts for the mutations in the given GRG.
@@ -46,26 +46,30 @@ def allele_counts(
     :type grg: pygrgl.GRG
     :param return_missing: Return two arrays: the allele counts, and the missingness counts.
     :type return_missing: bool
-    :param sample_filter: Optional. Restrict the counts to a subset of samples, listed by sample node ID.
-    :type sample_filter: List[int]
-    :param mask_samples: Ignore any contribution from the samples listed in this array.
-    :type mask_samples: Union[List[int], numpy.typing.NDArray]
+    :param sample_filter: Only consider the samples listed in the filter. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     :return: A vector of length grg.num_mutations, containing allele counts
         indexed by MutationID.
     :rtype: numpy.ndarray
     """
-    assert (
-        isinstance(mask_samples, list) or mask_samples.ndim == 1
-    ), "mask_samples must be a list or 1D array"
+    if isinstance(sample_filter, numpy.ndarray):
+        sample_filter = sample_filter.tolist()
+    if sample_filter is not None:
+        assert len(set(sample_filter)) == len(
+            sample_filter
+        ), "Duplicate IDs in sample_filter"
+        assert len(sample_filter) <= grg.num_samples
     kwargs = {}
     if return_missing:
         miss_counts = numpy.zeros((1, grg.num_mutations), dtype=numpy.int32)
         kwargs["miss"] = miss_counts
     else:
         miss_counts = None
-    input_mat = numpy.ones((1, grg.num_samples), dtype=numpy.int32)
-    if mask_samples:
-        input_mat[:, mask_samples] = 0
+    if sample_filter is not None:
+        input_mat = numpy.zeros((1, grg.num_samples), dtype=numpy.int32)
+        input_mat[:, sample_filter] = 1
+    else:
+        input_mat = numpy.ones((1, grg.num_samples), dtype=numpy.int32)
     acounts = pygrgl.matmul(grg, input_mat, pygrgl.TraversalDirection.UP, **kwargs)[0]
     if miss_counts is not None:
         miss_counts = miss_counts[0]
@@ -77,7 +81,7 @@ def allele_counts(
 def allele_frequencies(
     grg: pygrgl.GRG,
     adjust_missing: bool = False,
-    mask_samples: Union[List[int], numpy.typing.NDArray] = [],
+    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
 ) -> numpy.typing.NDArray:
     """
     Get the allele frequencies for the mutations in the given GRG.
@@ -87,8 +91,8 @@ def allele_frequencies(
     :param adjust_missing: Optional. Set to true to adjust each allele frequncies to be
         :math:`\\frac{count_i}{total - missing_i}` instead of :math:`\\frac{count_i}{total}`.
     :type adjust_missing: bool
-    :param mask_samples: Ignore any contribution from the samples listed in this array.
-    :type mask_samples: Union[List[int], numpy.typing.NDArray]
+    :param sample_filter: Only consider the samples listed in the filter. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     :return: A vector of length grg.num_mutations, containing allele frequencies
         indexed by MutationID.
     :rtype: numpy.ndarray
@@ -96,14 +100,15 @@ def allele_frequencies(
     with numpy.errstate(divide="raise"):
         if adjust_missing:
             acounts, miss_counts = allele_counts(
-                grg, return_missing=True, mask_samples=mask_samples
+                grg, return_missing=True, sample_filter=sample_filter
             )
         else:
             acounts = allele_counts(
-                grg, return_missing=False, mask_samples=mask_samples
+                grg, return_missing=False, sample_filter=sample_filter
             )
             miss_counts = 0
-        denominator = grg.num_samples - miss_counts - len(mask_samples)
+        num_samples = grg.num_samples if sample_filter is None else len(sample_filter)
+        denominator = num_samples - miss_counts
         assert numpy.all(denominator >= 0)
         return numpy.divide(
             acounts,
@@ -117,7 +122,7 @@ def variance(
     grg: pygrgl.GRG,
     dist: str = _GenotypeDist.BINOMIAL.value,
     adjust_missing: bool = False,
-    mask_samples: Union[List[int], numpy.typing.NDArray] = [],
+    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
     haploid: bool = False,
 ):
     """
@@ -131,15 +136,15 @@ def variance(
     :param adjust_missing: Optional. Set to true to adjust each allele frequncy to be
         :math:`\\frac{count_i}{total - missing_i}` instead of :math:`\\frac{count_i}{total}`.
     :type adjust_missing: bool
-    :param mask_samples: Ignore any contribution from the samples listed in this array.
-    :type mask_samples: Union[List[int], numpy.typing.NDArray]
+    :param sample_filter: Only consider the samples listed in the filter. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
     :return: A vector of length grg.num_mutations, containing allele frequencies
         indexed by MutationID.
     :rtype: numpy.ndarray
     """
     mult_const = 1 if haploid else grg.ploidy
     acount, miss_count = allele_counts(
-        grg, return_missing=True, mask_samples=mask_samples
+        grg, return_missing=True, sample_filter=sample_filter
     )
     n_j = (
         (grg.num_samples - miss_count)

--- a/test/linalg/test_ops.py
+++ b/test/linalg/test_ops.py
@@ -17,6 +17,7 @@ import os
 import pygrgl
 import sys
 import unittest
+import pytest
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(THIS_DIR, ".."))
@@ -454,9 +455,9 @@ class TestLinearOperators(unittest.TestCase):
         grg_result = rv @ X_nomiss_op.T
         self.assertFalse(numpy.allclose(numpy_result, grg_result))
 
-    def test_ignore_samples(self):
+    def test_filter_samples(self):
         """
-        We downsample a GRG explicitly, and then use an operator's mask to ignore the same individuals,
+        We downsample a GRG explicitly, and then use an operator's filter to ignore the same individuals,
         and expect the matrix multiplication should produce the same result.
         """
         keep_indivs, ignore_indivs, keep_samples, ignore_samples = complete_sample_sets(
@@ -468,33 +469,86 @@ class TestLinearOperators(unittest.TestCase):
         filt_grg = pygrgl.load_immutable_grg(filt_name, load_up_edges=False)
 
         K = 17
-        Y = numpy.random.standard_normal((K, self.grg.num_individuals))
-        sub_Y = Y[:, keep_indivs]
+        Y = numpy.random.standard_normal((K, len(keep_indivs)))
 
         # Non-standardized operator
         truth_op = SciPyXOperator(filt_grg, pygrgl.TraversalDirection.UP)
-        truth_matrix = sub_Y @ truth_op
+        truth_matrix = Y @ truth_op
         mask_op = SciPyXOperator(
-            self.grg, pygrgl.TraversalDirection.UP, mask_samples=ignore_indivs
+            self.grg,
+            pygrgl.TraversalDirection.UP,
+            sample_filter=keep_indivs,
         )
         mask_matrix = Y @ mask_op
         numpy.testing.assert_allclose(truth_matrix, mask_matrix)
 
         # Standardized operator
         truth_freqs = allele_frequencies(filt_grg)
-        mask_freqs = allele_frequencies(self.grg, mask_samples=ignore_samples)
+        mask_freqs = allele_frequencies(self.grg, sample_filter=keep_samples)
         numpy.testing.assert_allclose(truth_freqs, mask_freqs, atol=ABSOLUTE_TOLERANCE)
 
         truth_op = SciPyStdXOperator(
             filt_grg, pygrgl.TraversalDirection.UP, truth_freqs
         )
-        truth_matrix = sub_Y @ truth_op
+        truth_matrix = Y @ truth_op
         mask_op = SciPyStdXOperator(
             self.grg,
             pygrgl.TraversalDirection.UP,
             mask_freqs,
-            mask_samples=ignore_indivs,
+            sample_filter=keep_indivs,
         )
+        mask_matrix = Y @ mask_op
+        numpy.testing.assert_allclose(
+            truth_matrix, mask_matrix, atol=ABSOLUTE_TOLERANCE
+        )
+
+        # Now do some testing with the DOWN direction
+        Y = numpy.random.standard_normal((K, self.grg.num_mutations))
+
+        # Non-standardized operator
+        truth_op = SciPyXOperator(filt_grg, pygrgl.TraversalDirection.DOWN)
+        truth_matrix = Y @ truth_op
+        mask_op = SciPyXOperator(
+            self.grg,
+            pygrgl.TraversalDirection.DOWN,
+            sample_filter=keep_indivs,
+        )
+        mask_matrix = Y @ mask_op
+        numpy.testing.assert_allclose(truth_matrix, mask_matrix)
+
+        # Standardized operator
+        truth_freqs = allele_frequencies(filt_grg)
+        mask_freqs = allele_frequencies(self.grg, sample_filter=keep_samples)
+        numpy.testing.assert_allclose(truth_freqs, mask_freqs, atol=ABSOLUTE_TOLERANCE)
+
+        truth_op = SciPyStdXOperator(
+            filt_grg, pygrgl.TraversalDirection.DOWN, truth_freqs
+        )
+        truth_matrix = Y @ truth_op
+        mask_op = SciPyStdXOperator(
+            self.grg,
+            pygrgl.TraversalDirection.DOWN,
+            mask_freqs,
+            sample_filter=keep_indivs,
+        )
+        mask_matrix = Y @ mask_op
+        numpy.testing.assert_allclose(
+            truth_matrix, mask_matrix, atol=ABSOLUTE_TOLERANCE
+        )
+
+        # XTX
+        truth_op = SciPyXTXOperator(filt_grg)
+        truth_matrix = Y @ truth_op
+        mask_op = SciPyXTXOperator(self.grg, sample_filter=keep_indivs)
+        mask_matrix = Y @ mask_op
+        numpy.testing.assert_allclose(
+            truth_matrix, mask_matrix, atol=ABSOLUTE_TOLERANCE
+        )
+
+        # XTX standardized
+        truth_op = SciPyStdXTXOperator(filt_grg, truth_freqs)
+        truth_matrix = Y @ truth_op
+        mask_op = SciPyStdXTXOperator(self.grg, mask_freqs, sample_filter=keep_indivs)
         mask_matrix = Y @ mask_op
         numpy.testing.assert_allclose(
             truth_matrix, mask_matrix, atol=ABSOLUTE_TOLERANCE


### PR DESCRIPTION
Change sample_filter and mutation_filter to behave in the same way. It was weird before, because mask_samples did not change the input/output shapes.

This should also fix an issue with the GWAS+covariates when there were a lot of missing phenotypes for non-standardized Y, which generated a bad Y_adj, because C's shape was not adjusted for the missing phenotypes.
Now, both Y and C have their shapes changed to simplify subsequent calculations.

Add more tests to cover the filtering scenarios.