### PR TITLE
Cupy Support

### DIFF
--- a/grapp/grg_calculator.py
+++ b/grapp/grg_calculator.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 import pygrgl
 import numpy
+import threading
 import concurrent.futures
 from typing import Optional, Union, Dict, Callable, List, Any
-from grapp.util.exceptions import UserInputError
 
 try:
     import pygrgl_spmv
@@ -138,6 +138,30 @@ class GRGThreadSched(GRGScheduler):
         return GRGThreadOp(self.executor.submit(operation, *args, **kwargs))
 
 
+class GRGGatedSched(GRGScheduler):
+    def __init__(self, executor: concurrent.futures.Executor, gated=False):
+        self.executor = executor
+        self.gated = gated
+        self._start_gate = threading.Event()
+        if not self.gated:
+            self._start_gate.set()
+
+    def _gated_operation(self, operation, *args, **kwargs):
+        self._start_gate.wait()
+        return operation(*args, **kwargs)
+    
+    def start(self) -> None:
+        self._start_gate.set()
+
+    def reset(self) -> None:
+        if not self.gated:
+            raise ValueError("Cannot reset a non-gated scheduler")
+        self._start_gate.clear()
+
+    def submit(self, grg: GRGCalcInterface, operation, *args, **kwargs) -> GRGWaitable:
+        return GRGThreadOp(self.executor.submit(self._gated_operation, operation, *args, **kwargs))
+
+
 class GRGCalculator(GRGCalcInterface):
     """
     Implementaion of the GRG calculator interface for the regular GRG. This is what most
@@ -220,6 +244,14 @@ class GRGSpMVCalculator(GRGCalcInterface):
         self._op = grg_spmv
 
     @property
+    def device(self) -> int | None:
+        return getattr(self._op, "device", None)
+    
+    @property
+    def use_cupy(self) -> bool:
+        return getattr(self._op, "use_cupy", False)
+
+    @property
     def num_samples(self) -> int:
         return self._op.num_samples
 
@@ -283,8 +315,9 @@ class GRGSpMVCalculator(GRGCalcInterface):
             miss=miss,
         )
 
-    def make_scheduler(self, grgs: List["GRGCalcInterface"], workers: int = 1):
-        return GRGSeqSched()
+    def make_scheduler(self, grgs: List["GRGCalcInterface"], workers: int = 1, gated: bool = False):
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
+        return GRGGatedSched(executor=executor, gated=gated)
 
 
 def load_grg_calculator(filename: str) -> GRGCalcInterface:
@@ -298,10 +331,14 @@ def load_grg_calculator(filename: str) -> GRGCalcInterface:
             )
         ),
     }
+    from grapp.util.exceptions import UserInputError
     if pygrgl_spmv is not None:
-        extension_to_loader[".grg_spmv"] = lambda filename: GRGSpMVCalculator(
-            pygrgl_spmv.load(filename)
-        )
+        def _raise_spmv_error(filename: str) -> GRGCalcInterface:
+            raise UserInputError(
+                "grg_spmv files cannot be loaded directly."
+            )
+
+        extension_to_loader[".grg_spmv"] = _raise_spmv_error
     for ext, loader in extension_to_loader.items():
         if filename.endswith(ext):
             return loader(filename)

--- a/grapp/grg_calculator.py
+++ b/grapp/grg_calculator.py
@@ -11,6 +11,132 @@ except ImportError:
     pygrgl_spmv = None  # typing: ignore
 
 
+def _scipy_operator_table() -> Dict[tuple, Callable]:
+    # Lazy import to avoid a circular import: grapp.linalg and grapp.util both import
+    # grapp.grg_calculator. Keys are (op, standardized, multi). "X" and "XT" share a class
+    # (distinguished by the direction passed to the constructor). The non-standardized multi-XXT
+    # operator is absent. "FREQ" maps to the allele-frequency function (not a LinearOperator),
+    # "EIGSH" to the sparse symmetric eigensolver, and "TO_NUMPY"/"FROM_NUMPY" to host<->backend
+    # array converters (no-ops here since the SciPy backend already uses numpy arrays).
+    from grapp.linalg import ops_scipy as m
+    from grapp.util.simple import allele_frequencies
+    from scipy.sparse.linalg import eigsh
+
+    return {
+        ("X", False, False): m.SciPyXOperator,
+        ("XT", False, False): m.SciPyXOperator,
+        ("XTX", False, False): m.SciPyXTXOperator,
+        ("XXT", False, False): m.SciPyXXTOperator,
+        ("X", True, False): m.SciPyStdXOperator,
+        ("XT", True, False): m.SciPyStdXOperator,
+        ("XTX", True, False): m.SciPyStdXTXOperator,
+        ("XXT", True, False): m.SciPyStdXXTOperator,
+        ("X", False, True): m.MultiSciPyXOperator,
+        ("XT", False, True): m.MultiSciPyXOperator,
+        ("XTX", False, True): m.MultiSciPyXTXOperator,
+        ("X", True, True): m.MultiSciPyStdXOperator,
+        ("XT", True, True): m.MultiSciPyStdXOperator,
+        ("XTX", True, True): m.MultiSciPyStdXTXOperator,
+        ("XXT", True, True): m.MultiSciPyStdXXTOperator,
+        ("FREQ", False, False): allele_frequencies,
+        ("FREQ", True, False): allele_frequencies,
+        ("EIGSH", False, False): eigsh,
+        ("EIGSH", True, False): eigsh,
+        ("TO_NUMPY", False, False): numpy.asarray,
+        ("TO_NUMPY", True, False): numpy.asarray,
+        ("FROM_NUMPY", False, False): numpy.asarray,
+        ("FROM_NUMPY", True, False): numpy.asarray,
+    }
+
+
+def _cupy_operator_table() -> Dict[tuple, Callable]:
+    # Lazy import; CuPy is only available when the GPU stack is installed.
+    import cupy
+    from grapp.linalg import ops_cupy as m
+    from grapp.util.simple import allele_frequencies_cupy
+    from cupyx.scipy.sparse.linalg import eigsh
+
+    def _to_numpy(arr):
+        # Sync the whole device so all in-flight kernels producing ``arr`` are
+        # complete before it is read back to the host.
+        cupy.cuda.Device().synchronize()
+        return cupy.asnumpy(arr)
+
+    def _from_numpy(arr):
+        # Upload to the device, then sync so the H2D copy is guaranteed complete
+        # before the array is consumed (possibly on another thread/stream).
+        out = cupy.asarray(arr)
+        cupy.cuda.Device().synchronize()
+        return out
+
+    return {
+        ("X", False, False): m.CuPyXOperator,
+        ("XT", False, False): m.CuPyXOperator,
+        ("XTX", False, False): m.CuPyXTXOperator,
+        ("XXT", False, False): m.CuPyXXTOperator,
+        ("X", True, False): m.CuPyStdXOperator,
+        ("XT", True, False): m.CuPyStdXOperator,
+        ("XTX", True, False): m.CuPyStdXTXOperator,
+        ("XXT", True, False): m.CuPyStdXXTOperator,
+        ("X", False, True): m.MultiCuPyXOperator,
+        ("XT", False, True): m.MultiCuPyXOperator,
+        ("XTX", False, True): m.MultiCuPyXTXOperator,
+        ("XXT", False, True): m.MultiCuPyXXTOperator,
+        ("X", True, True): m.MultiCuPyStdXOperator,
+        ("XT", True, True): m.MultiCuPyStdXOperator,
+        ("XTX", True, True): m.MultiCuPyStdXTXOperator,
+        ("XXT", True, True): m.MultiCuPyStdXXTOperator,
+        ("FREQ", False, False): allele_frequencies_cupy,
+        ("FREQ", True, False): allele_frequencies_cupy,
+        ("EIGSH", False, False): eigsh,
+        ("EIGSH", True, False): eigsh,
+        ("TO_NUMPY", False, False): _to_numpy,
+        ("TO_NUMPY", True, False): _to_numpy,
+        ("FROM_NUMPY", False, False): _from_numpy,
+        ("FROM_NUMPY", True, False): _from_numpy,
+    }
+
+
+def _select_operator_cls(backend: str, op: str, standardized: bool, multi: bool) -> Callable:
+    """
+    Map (op, standardized, multi) to a LinearOperator class (or, for the non-matrix ops, a callable)
+    for the given backend, hiding the SciPy/CuPy choice from downstream code. Returns the
+    class/callable, not an instance/result; the caller invokes it with whatever arguments it needs
+    (grg(s), direction, freqs, ...). The non-matrix ops are: ``"FREQ"`` (allele-frequency function),
+    ``"EIGSH"`` (sparse symmetric eigensolver), and ``"TO_NUMPY"``/``"FROM_NUMPY"`` (host<->backend
+    array converters).
+
+    :param backend: ``"SciPy"`` or ``"CuPy"``.
+    :param op: One of ``"X"``, ``"XT"``, ``"XTX"``, ``"XXT"``, ``"FREQ"``, ``"EIGSH"``,
+        ``"TO_NUMPY"``, ``"FROM_NUMPY"`` (case-insensitive).
+    :param standardized: Select the standardized (mean/variance-scaled) operator. Ignored for the
+        non-matrix ops.
+    :param multi: Select the multi-GRG variant.
+    :raises ValueError: For an unrecognized ``op`` or ``backend``.
+    :raises NotImplementedError: When the backend has no entry for the requested combination
+        (e.g. the non-standardized multi-XXT operator does not exist for SciPy, and the non-matrix
+        ops have no multi variant).
+    """
+    op = op.upper()
+    if op not in ("X", "XT", "XTX", "XXT", "FREQ", "EIGSH", "TO_NUMPY", "FROM_NUMPY"):
+        raise ValueError(
+            f"Unknown operator {op!r}. Expected one of 'X', 'XT', 'XTX', 'XXT', 'FREQ', 'EIGSH', "
+            f"'TO_NUMPY', 'FROM_NUMPY'."
+        )
+    if backend == "SciPy":
+        table = _scipy_operator_table()
+    elif backend == "CuPy":
+        table = _cupy_operator_table()
+    else:
+        raise ValueError(f"Unknown backend {backend!r}. Expected 'SciPy' or 'CuPy'.")
+    cls = table.get((op, standardized, multi))
+    if cls is None:
+        raise NotImplementedError(
+            f"No {backend} operator for op={op!r}, standardized={standardized}, multi={multi}."
+        )
+    return cls
+
+
 class GRGWaitable(ABC):
     """
     Generic interface for a GRG-related job that can be waited upon.
@@ -103,6 +229,25 @@ class GRGCalcInterface(ABC):
 
     @abstractmethod
     def make_scheduler(self, grgs: List["GRGCalcInterface"], workers: int = 1):
+        pass
+
+    @abstractmethod
+    def get_operator(self, op: str, standardized: bool) -> Callable:
+        """
+        Return the single-GRG LinearOperator class for ``op`` ("X", "XT", "XTX", "XXT"), choosing
+        the backend (SciPy/CuPy) appropriate for this calculator. Returns the class, not an
+        instance; the caller constructs it (passing direction for "X"/"XT", freqs when standardized).
+
+        ``op="freq"`` and ``op="eigsh"`` instead returns the backend's allele-frequency function, which the caller
+        invokes as ``fn(grg, ...)``.
+        """
+        pass
+
+    @abstractmethod
+    def get_multi_operator(self, op: str, standardized: bool) -> Callable:
+        """
+        Like :meth:`get_operator`, but returns the multi-GRG ("Multi...") LinearOperator class.
+        """
         pass
 
 
@@ -234,6 +379,12 @@ class GRGCalculator(GRGCalcInterface):
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
         return GRGThreadSched(executor)
 
+    def get_operator(self, op: str, standardized: bool) -> Callable:
+        return _select_operator_cls("SciPy", op, standardized, multi=False)
+
+    def get_multi_operator(self, op: str, standardized: bool) -> Callable:
+        return _select_operator_cls("SciPy", op, standardized, multi=True)
+
 
 class GRGSpMVCalculator(GRGCalcInterface):
     """
@@ -318,6 +469,14 @@ class GRGSpMVCalculator(GRGCalcInterface):
     def make_scheduler(self, grgs: List["GRGCalcInterface"], workers: int = 1, gated: bool = False):
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
         return GRGGatedSched(executor=executor, gated=gated)
+
+    def get_operator(self, op: str, standardized: bool) -> Callable:
+        backend = "CuPy" if self.use_cupy else "SciPy"
+        return _select_operator_cls(backend, op, standardized, multi=False)
+
+    def get_multi_operator(self, op: str, standardized: bool) -> Callable:
+        backend = "CuPy" if self.use_cupy else "SciPy"
+        return _select_operator_cls(backend, op, standardized, multi=True)
 
 
 def load_grg_calculator(filename: str) -> GRGCalcInterface:

--- a/grapp/grg_calculator.py
+++ b/grapp/grg_calculator.py
@@ -3,6 +3,7 @@ import pygrgl
 import numpy
 import threading
 import concurrent.futures
+import contextlib
 from typing import Optional, Union, Dict, Callable, List, Any
 
 try:
@@ -10,16 +11,20 @@ try:
 except ImportError:
     pygrgl_spmv = None  # typing: ignore
 
+try:
+    import cupy
+except ImportError:
+    cupy = None  # typing: ignore
+
 
 def _scipy_operator_table() -> Dict[tuple, Callable]:
     # Lazy import to avoid a circular import: grapp.linalg and grapp.util both import
     # grapp.grg_calculator. Keys are (op, standardized, multi). "X" and "XT" share a class
     # (distinguished by the direction passed to the constructor). The non-standardized multi-XXT
-    # operator is absent. "FREQ" maps to the allele-frequency function (not a LinearOperator),
-    # "EIGSH" to the sparse symmetric eigensolver, and "TO_NUMPY"/"FROM_NUMPY" to host<->backend
-    # array converters (no-ops here since the SciPy backend already uses numpy arrays).
+    # operator is absent. "EIGSH" maps to the sparse symmetric eigensolver.
+    # All interfaces take numpy arrays and return numpy arrays, conversion to/from cupy arrays
+    # should be done internally!
     from grapp.linalg import ops_scipy as m
-    from grapp.util.simple import allele_frequencies
     from scipy.sparse.linalg import eigsh
 
     return {
@@ -38,36 +43,28 @@ def _scipy_operator_table() -> Dict[tuple, Callable]:
         ("XT", True, True): m.MultiSciPyStdXOperator,
         ("XTX", True, True): m.MultiSciPyStdXTXOperator,
         ("XXT", True, True): m.MultiSciPyStdXXTOperator,
-        ("FREQ", False, False): allele_frequencies,
-        ("FREQ", True, False): allele_frequencies,
         ("EIGSH", False, False): eigsh,
         ("EIGSH", True, False): eigsh,
-        ("TO_NUMPY", False, False): numpy.asarray,
-        ("TO_NUMPY", True, False): numpy.asarray,
-        ("FROM_NUMPY", False, False): numpy.asarray,
-        ("FROM_NUMPY", True, False): numpy.asarray,
     }
 
 
 def _cupy_operator_table() -> Dict[tuple, Callable]:
-    # Lazy import; CuPy is only available when the GPU stack is installed.
-    import cupy
+    assert (
+        cupy is not None
+    ), "cupy not installed; try 'pip install cupy' or use a different backend"
     from grapp.linalg import ops_cupy as m
-    from grapp.util.simple import allele_frequencies_cupy
     from cupyx.scipy.sparse.linalg import eigsh
 
-    def _to_numpy(arr):
-        # Sync the whole device so all in-flight kernels producing ``arr`` are
-        # complete before it is read back to the host.
-        cupy.cuda.Device().synchronize()
-        return cupy.asnumpy(arr)
+    def _eigsh(A, **kwargs):
+        def _convert_if_present(kwargs, key):
+            if key in kwargs:
+                kwargs[key] = cupy.asarray(kwargs[key])
 
-    def _from_numpy(arr):
-        # Upload to the device, then sync so the H2D copy is guaranteed complete
-        # before the array is consumed (possibly on another thread/stream).
-        out = cupy.asarray(arr)
+        _convert_if_present(kwargs, "M")
+        _convert_if_present(kwargs, "v0")
+        eigval, eigvect = eigsh(cupy.asarray(A), **kwargs)
         cupy.cuda.Device().synchronize()
-        return out
+        return cupy.asnumpy(eigval), cupy.asnumpy(eigvect)
 
     return {
         ("X", False, False): m.CuPyXOperator,
@@ -86,18 +83,14 @@ def _cupy_operator_table() -> Dict[tuple, Callable]:
         ("XT", True, True): m.MultiCuPyStdXOperator,
         ("XTX", True, True): m.MultiCuPyStdXTXOperator,
         ("XXT", True, True): m.MultiCuPyStdXXTOperator,
-        ("FREQ", False, False): allele_frequencies_cupy,
-        ("FREQ", True, False): allele_frequencies_cupy,
-        ("EIGSH", False, False): eigsh,
-        ("EIGSH", True, False): eigsh,
-        ("TO_NUMPY", False, False): _to_numpy,
-        ("TO_NUMPY", True, False): _to_numpy,
-        ("FROM_NUMPY", False, False): _from_numpy,
-        ("FROM_NUMPY", True, False): _from_numpy,
+        ("EIGSH", False, False): _eigsh,
+        ("EIGSH", True, False): _eigsh,
     }
 
 
-def _select_operator_cls(backend: str, op: str, standardized: bool, multi: bool) -> Callable:
+def _select_operator_cls(
+    backend: str, op: str, standardized: bool, multi: bool
+) -> Callable:
     """
     Map (op, standardized, multi) to a LinearOperator class (or, for the non-matrix ops, a callable)
     for the given backend, hiding the SciPy/CuPy choice from downstream code. Returns the
@@ -228,7 +221,9 @@ class GRGCalcInterface(ABC):
         pass
 
     @abstractmethod
-    def make_scheduler(self, grgs: List["GRGCalcInterface"], workers: int = 1):
+    def make_scheduler(
+        self, grgs: List["GRGCalcInterface"], workers: int = 1, gated: bool = False
+    ):
         pass
 
     @abstractmethod
@@ -248,6 +243,10 @@ class GRGCalcInterface(ABC):
         """
         Like :meth:`get_operator`, but returns the multi-GRG ("Multi...") LinearOperator class.
         """
+        pass
+
+    @abstractmethod
+    def device_context(self):
         pass
 
 
@@ -294,7 +293,7 @@ class GRGGatedSched(GRGScheduler):
     def _gated_operation(self, operation, *args, **kwargs):
         self._start_gate.wait()
         return operation(*args, **kwargs)
-    
+
     def start(self) -> None:
         self._start_gate.set()
 
@@ -304,7 +303,9 @@ class GRGGatedSched(GRGScheduler):
         self._start_gate.clear()
 
     def submit(self, grg: GRGCalcInterface, operation, *args, **kwargs) -> GRGWaitable:
-        return GRGThreadOp(self.executor.submit(self._gated_operation, operation, *args, **kwargs))
+        return GRGThreadOp(
+            self.executor.submit(self._gated_operation, operation, *args, **kwargs)
+        )
 
 
 class GRGCalculator(GRGCalcInterface):
@@ -375,7 +376,9 @@ class GRGCalculator(GRGCalcInterface):
             miss=miss,
         )
 
-    def make_scheduler(self, grgs: List["GRGCalcInterface"], workers: int = 1):
+    def make_scheduler(
+        self, grgs: List["GRGCalcInterface"], workers: int = 1, gated: bool = False
+    ):
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
         return GRGThreadSched(executor)
 
@@ -384,6 +387,9 @@ class GRGCalculator(GRGCalcInterface):
 
     def get_multi_operator(self, op: str, standardized: bool) -> Callable:
         return _select_operator_cls("SciPy", op, standardized, multi=True)
+
+    def device_context(self):
+        return contextlib.suppress()
 
 
 class GRGSpMVCalculator(GRGCalcInterface):
@@ -397,7 +403,7 @@ class GRGSpMVCalculator(GRGCalcInterface):
     @property
     def device(self) -> int | None:
         return getattr(self._op, "device", None)
-    
+
     @property
     def use_cupy(self) -> bool:
         return getattr(self._op, "use_cupy", False)
@@ -457,16 +463,25 @@ class GRGSpMVCalculator(GRGCalcInterface):
         init: Optional[Union[str, numpy.typing.NDArray]] = None,
         miss: Optional[numpy.typing.NDArray] = None,
     ) -> numpy.typing.NDArray:
-        return self._op.matmul(
-            input,
+        mm_input = cupy.asarray(input) if self.use_cupy else input
+        mm_init = cupy.asarray(init) if self.use_cupy else init
+        mm_miss = cupy.asarray(miss) if self.use_cupy else miss
+        result = self._op.matmul(
+            mm_input,
             self._convert_dir(direction),
             emit_all_nodes=emit_all_nodes,
             by_individual=by_individual,
-            init=init,
-            miss=miss,
+            init=mm_init,
+            miss=mm_miss,
         )
+        if self.use_cupy:
+            cupy.cuda.Device().synchronize()
+            result = cupy.asnumpy()
+        return result
 
-    def make_scheduler(self, grgs: List["GRGCalcInterface"], workers: int = 1, gated: bool = False):
+    def make_scheduler(
+        self, grgs: List["GRGCalcInterface"], workers: int = 1, gated: bool = False
+    ):
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
         return GRGGatedSched(executor=executor, gated=gated)
 
@@ -477,6 +492,9 @@ class GRGSpMVCalculator(GRGCalcInterface):
     def get_multi_operator(self, op: str, standardized: bool) -> Callable:
         backend = "CuPy" if self.use_cupy else "SciPy"
         return _select_operator_cls(backend, op, standardized, multi=True)
+
+    def device_context(self):
+        return cupy.cuda.Device(self.device) if self.use_cupy else contextlib.suppress()
 
 
 def load_grg_calculator(filename: str) -> GRGCalcInterface:
@@ -491,11 +509,11 @@ def load_grg_calculator(filename: str) -> GRGCalcInterface:
         ),
     }
     from grapp.util.exceptions import UserInputError
+
     if pygrgl_spmv is not None:
+
         def _raise_spmv_error(filename: str) -> GRGCalcInterface:
-            raise UserInputError(
-                "grg_spmv files cannot be loaded directly."
-            )
+            raise UserInputError("grg_spmv files cannot be loaded directly.")
 
         extension_to_loader[".grg_spmv"] = _raise_spmv_error
     for ext, loader in extension_to_loader.items():

--- a/grapp/grg_calculator.py
+++ b/grapp/grg_calculator.py
@@ -62,7 +62,7 @@ def _cupy_operator_table() -> Dict[tuple, Callable]:
 
         _convert_if_present(kwargs, "M")
         _convert_if_present(kwargs, "v0")
-        eigval, eigvect = eigsh(cupy.asarray(A), **kwargs)
+        eigval, eigvect = eigsh(A, **kwargs)
         cupy.cuda.Device().synchronize()
         return cupy.asnumpy(eigval), cupy.asnumpy(eigvect)
 
@@ -249,6 +249,14 @@ class GRGCalcInterface(ABC):
     def device_context(self):
         pass
 
+    @abstractmethod
+    def get_raw(self):
+        pass
+
+    @abstractmethod
+    def _convert_dir(self, d):
+        pass
+
 
 class GRGSeqOp(GRGWaitable):
     def __init__(self, value):
@@ -391,6 +399,12 @@ class GRGCalculator(GRGCalcInterface):
     def device_context(self):
         return contextlib.suppress()
 
+    def get_raw(self):
+        return self.grg
+
+    def _convert_dir(self, d):
+        return d
+
 
 class GRGSpMVCalculator(GRGCalcInterface):
     """
@@ -463,21 +477,34 @@ class GRGSpMVCalculator(GRGCalcInterface):
         init: Optional[Union[str, numpy.typing.NDArray]] = None,
         miss: Optional[numpy.typing.NDArray] = None,
     ) -> numpy.typing.NDArray:
-        mm_input = cupy.asarray(input) if self.use_cupy else input
-        mm_init = cupy.asarray(init) if self.use_cupy else init
-        mm_miss = cupy.asarray(miss) if self.use_cupy else miss
-        result = self._op.matmul(
-            mm_input,
-            self._convert_dir(direction),
-            emit_all_nodes=emit_all_nodes,
-            by_individual=by_individual,
-            init=mm_init,
-            miss=mm_miss,
-        )
         if self.use_cupy:
-            cupy.cuda.Device().synchronize()
-            result = cupy.asnumpy()
+            with cupy.cuda.Device(self.device):
+                mm_input = cupy.asarray(input)
+                mm_init = cupy.asarray(init) if init is not None else init
+                mm_miss = cupy.asarray(miss) if miss is not None else miss
+                result = self._op.matmul(
+                    mm_input,
+                    self._convert_dir(direction),
+                    emit_all_nodes=emit_all_nodes,
+                    by_individual=by_individual,
+                    init=mm_init,
+                    miss=mm_miss,
+                )
+                cupy.cuda.Device().synchronize()
+                result = cupy.asnumpy(result)
+        else:
+            result = self._op.matmul(
+                input,
+                self._convert_dir(direction),
+                emit_all_nodes=emit_all_nodes,
+                by_individual=by_individual,
+                init=init,
+                miss=miss,
+            )
         return result
+
+    def get_raw(self):
+        return self._op
 
     def make_scheduler(
         self, grgs: List["GRGCalcInterface"], workers: int = 1, gated: bool = False

--- a/grapp/grg_calculator.py
+++ b/grapp/grg_calculator.py
@@ -415,7 +415,7 @@ class GRGSpMVCalculator(GRGCalcInterface):
         self._op = grg_spmv
 
     @property
-    def device(self) -> int | None:
+    def device(self) -> Optional[int]:
         return getattr(self._op, "device", None)
 
     @property

--- a/grapp/linalg/__init__.py
+++ b/grapp/linalg/__init__.py
@@ -15,7 +15,7 @@ from scipy.sparse.linalg import eigsh
 from typing import Tuple, List, Dict, Any, Union, Optional
 
 from grapp.util import allele_frequencies as _allele_frequencies
-from grapp.grg_calculator import GRGCalcInterface as _GRGCalcInterface
+from grapp.grg_calculator import GRGCalcInterface as _GRGCalcInterface, _wrap_grg
 
 # Everything below is imported so that users can import them via grapp.linalg
 from grapp.linalg.ops_scipy import (  # noqa: F401
@@ -180,39 +180,47 @@ def get_eig_pcs(
     :return: A pair (PC_scores, eigen_values) where each is a numpy array.
     :rtype: Tuple[numpy.ndarray, numpy.ndarray, Optional[numpy.ndarray]]
     """
+    # Route everything through the backend-agnostic operator selector so this works for both the
+    # NumPy (GRGCalculator) and CuPy (GRGSpMVCalculator) backends.
+    is_list = isinstance(grgs, list)
+    grg_list = [_wrap_grg(g) for g in grgs] if is_list else None
+    grg = None if is_list else _wrap_grg(grgs)
+    repr_grg = grg_list[0] if is_list else grg
+
+    freq_fn = repr_grg.get_operator("freq", standardized=True)
+    eigsh_fn = repr_grg.get_operator("eigsh", standardized=True)
+    to_numpy = repr_grg.get_operator("to_numpy", standardized=True)
+    from_numpy = repr_grg.get_operator("from_numpy", standardized=True)
+    op_name = "XTX" if do_xtx else "XXT"
+
     freqs: Union[List[numpy.typing.NDArray], numpy.typing.NDArray]
-    if isinstance(grgs, list):
+    if is_list:
         executor = concurrent.futures.ThreadPoolExecutor(threads)
-        futures = [executor.submit(_allele_frequencies, grg) for grg in grgs]
+        futures = [executor.submit(freq_fn, grg) for grg in grg_list]
         freqs = [f.result() for f in futures]
-        if do_xtx:
-            op = MultiSciPyStdXTXOperator(
-                grgs, freqs, haploid=False, threads=threads, **op_kwargs
-            )
-        else:
-            op = MultiSciPyStdXXTOperator(
-                grgs, freqs, haploid=False, threads=threads, **op_kwargs
-            )
+        op = repr_grg.get_multi_operator(op_name, standardized=True)(
+            grg_list, freqs, haploid=False, threads=threads, **op_kwargs
+        )
     else:
-        freqs = _allele_frequencies(grgs, adjust_missing=True)
-        if do_xtx:
-            op = SciPyStdXTXOperator(grgs, freqs, haploid=False, **op_kwargs)
-        else:
-            op = SciPyStdXXTOperator(grgs, freqs, haploid=False, **op_kwargs)
+        freqs = freq_fn(grg, adjust_missing=True)
+        op = repr_grg.get_operator(op_name, standardized=True)(
+            grg, freqs, haploid=False, **op_kwargs
+        )
     if verbose:
         what = "variants" if do_xtx else "individuals"
         print(f"Running eigen decomposition on {op.shape[0]} {what}")
 
-    eigen_values, eigen_vectors = eigsh(op, k=k, which="LM")
+    eigen_values, eigen_vectors = eigsh_fn(op, k=k, which="LM")
+    eigen_values, eigen_vectors = to_numpy(eigen_values), to_numpy(eigen_vectors)
     sort_by_eigvalues(eigen_values, eigen_vectors)
     assert eigen_vectors.real.dtype == numpy.float64
     if not do_xtx:
         return eigen_vectors, eigen_values, None
 
     # If we did X^TX then we need to get the PC scores by performing one more product
-    if isinstance(grgs, list):
-        pc_op = MultiSciPyStdXOperator(
-            grgs,
+    if is_list:
+        pc_op = repr_grg.get_multi_operator("X", standardized=True)(
+            grg_list,
             pygrgl.TraversalDirection.UP,
             freqs,  # type: ignore
             haploid=False,
@@ -220,16 +228,17 @@ def get_eig_pcs(
             **op_kwargs,
         )
     else:
-        pc_op = SciPyStdXOperator(
-            grgs,
+        pc_op = repr_grg.get_operator("X", standardized=True)(
+            grg,
             pygrgl.TraversalDirection.UP,
             freqs,  # type: ignore
             haploid=False,
             **op_kwargs,
         )
-    # ... and then scaling the result
+    
     PC_scores = (
-        pc_op._matmat(eigen_vectors.real) / numpy.sqrt(eigen_values.real)[None, :]
+        to_numpy(pc_op._matmat(from_numpy(eigen_vectors.real)))
+        / numpy.sqrt(eigen_values.real)[None, :]
     )
     return PC_scores, eigen_values, eigen_vectors
 

--- a/grapp/linalg/__init__.py
+++ b/grapp/linalg/__init__.py
@@ -194,43 +194,40 @@ def get_eig_pcs(
     """
     # Route everything through the backend-agnostic operator selector so this works for both the
     # NumPy (GRGCalculator) and CuPy (GRGSpMVCalculator) backends.
-    is_list = isinstance(grgs, list)
-    grg_list = [_wrap_grg(g) for g in grgs] if is_list else None
-    grg = None if is_list else _wrap_grg(grgs)
-    repr_grg = grg_list[0] if is_list else grg
+    grg_list = (
+        [_wrap_grg(g) for g in grgs] if isinstance(grgs, list) else [_wrap_grg(grgs)]
+    )
+    repr_grg = grg_list[0]
 
-    freq_fn = repr_grg.get_operator("freq", standardized=True)
     eigsh_fn = repr_grg.get_operator("eigsh", standardized=True)
-    to_numpy = repr_grg.get_operator("to_numpy", standardized=True)
-    from_numpy = repr_grg.get_operator("from_numpy", standardized=True)
     op_name = "XTX" if do_xtx else "XXT"
 
     freqs: Union[List[numpy.typing.NDArray], numpy.typing.NDArray]
-    if is_list:
+    if len(grg_list) > 1:
         executor = concurrent.futures.ThreadPoolExecutor(threads)
-        futures = [executor.submit(freq_fn, grg) for grg in grg_list]
+        futures = [executor.submit(_allele_frequencies, grg) for grg in grg_list]
         freqs = [f.result() for f in futures]
         op = repr_grg.get_multi_operator(op_name, standardized=True)(
             grg_list, freqs, haploid=False, threads=threads, **op_kwargs
         )
     else:
-        freqs = freq_fn(grg, adjust_missing=True)
+        assert len(grg_list) > 0
+        freqs = _allele_frequencies(grg_list[0], adjust_missing=True)
         op = repr_grg.get_operator(op_name, standardized=True)(
-            grg, freqs, haploid=False, **op_kwargs
+            grg_list[0], freqs, haploid=False, **op_kwargs
         )
     if verbose:
         what = "variants" if do_xtx else "individuals"
         print(f"Running eigen decomposition on {op.shape[0]} {what}")
 
     eigen_values, eigen_vectors = eigsh_fn(op, k=k, which="LM", v0=init_vector, tol=tol)
-    eigen_values, eigen_vectors = to_numpy(eigen_values), to_numpy(eigen_vectors)
     sort_by_eigvalues(eigen_values, eigen_vectors)
     assert eigen_vectors.real.dtype == numpy.float64
     if not do_xtx:
         return eigen_vectors, eigen_values, None
 
     # If we did X^TX then we need to get the PC scores by performing one more product
-    if is_list:
+    if len(grg_list) > 1:
         pc_op = repr_grg.get_multi_operator("X", standardized=True)(
             grg_list,
             pygrgl.TraversalDirection.UP,
@@ -241,16 +238,15 @@ def get_eig_pcs(
         )
     else:
         pc_op = repr_grg.get_operator("X", standardized=True)(
-            grg,
+            grg_list[0],
             pygrgl.TraversalDirection.UP,
             freqs,  # type: ignore
             haploid=False,
             **op_kwargs,
         )
-    
+
     PC_scores = (
-        to_numpy(pc_op._matmat(from_numpy(eigen_vectors.real)))
-        / numpy.sqrt(eigen_values.real)[None, :]
+        pc_op._matmat(eigen_vectors.real) / numpy.sqrt(eigen_values.real)[None, :]
     )
     return PC_scores, eigen_values, eigen_vectors
 
@@ -266,7 +262,7 @@ def PCs(
     threads: int = 1,
     init_vector: Optional[numpy.typing.NDArray] = None,
     tol: float = 0,
-    include_eig_val: bool = False
+    include_eig_val: bool = False,
 ):
     """
     Get the principal components for each sample corresponding to the first :math:`k` eigenvectors from a GRG.

--- a/grapp/linalg/__init__.py
+++ b/grapp/linalg/__init__.py
@@ -159,10 +159,17 @@ def get_eig_pcs(
     threads: int = 1,
     verbose: bool = True,
     do_xtx: bool = False,
+    init_vector: Optional[numpy.typing.NDArray] = None,
+    tol: float = 0,
 ) -> Tuple[NDArray, NDArray, Optional[NDArray]]:
     """
     Get the principal components for each sample corresponding to the first :math:`k` eigenvectors from a GRG,
     using an iterative eigenvector decomposition method.
+
+    The computation is routed through the backend-agnostic operator selector on
+    :class:`~grapp.grg_calculator.GRGCalcInterface`, so it runs on either the NumPy/CPU backend
+    (``GRGCalculator``) or the CuPy/GPU backend (``GRGSpMVCalculator``) depending on the GRG passed
+    in. Regardless of backend, the returned arrays are host NumPy arrays.
 
     :param grgs: The GRG or list of GRGs to perform PCA on.
     :type grgs: Union[pygrgl.GRG, List[pygrgl.GRG]]
@@ -174,9 +181,14 @@ def get_eig_pcs(
     :param threads: Maximum number of threads to use. At most len(grgs) tasks can be done in parallel.
     :type threads: int
     :param verbose: Emit information on stderr.
-    :type verboose: bool
+    :type verbose: bool
     :param do_xtx: Use eigsh(X^TX) instead of the default eigsh(XX^T). Default: False.
     :type do_xtx: bool
+    :param init_vector: Optional starting vector for the iterative solver, passed to eigsh as ``v0``.
+    :type init_vector: Optional[numpy.typing.NDArray]
+    :param tol: Convergence tolerance for the iterative solver, passed to eigsh. 0 means machine
+        precision. Default: 0.
+    :type tol: float
     :return: A pair (PC_scores, eigen_values) where each is a numpy array.
     :rtype: Tuple[numpy.ndarray, numpy.ndarray, Optional[numpy.ndarray]]
     """
@@ -210,7 +222,7 @@ def get_eig_pcs(
         what = "variants" if do_xtx else "individuals"
         print(f"Running eigen decomposition on {op.shape[0]} {what}")
 
-    eigen_values, eigen_vectors = eigsh_fn(op, k=k, which="LM")
+    eigen_values, eigen_vectors = eigsh_fn(op, k=k, which="LM", v0=init_vector, tol=tol)
     eigen_values, eigen_vectors = to_numpy(eigen_values), to_numpy(eigen_vectors)
     sort_by_eigvalues(eigen_values, eigen_vectors)
     assert eigen_vectors.real.dtype == numpy.float64
@@ -252,6 +264,9 @@ def PCs(
     use_pro_pca: bool = False,
     sample_window: int = 1,
     threads: int = 1,
+    init_vector: Optional[numpy.typing.NDArray] = None,
+    tol: float = 0,
+    include_eig_val: bool = False
 ):
     """
     Get the principal components for each sample corresponding to the first :math:`k` eigenvectors from a GRG.
@@ -272,6 +287,14 @@ def PCs(
     :param threads: Number of threads to use. Will never use more than the number of input GRGs.
         Default: 1.
     :type threads: int
+    :param init_vector: Optional starting vector for the iterative solver, passed to eigsh as ``v0``.
+    :type init_vector: Optional[numpy.typing.NDArray]
+    :param tol: Convergence tolerance for the iterative solver, passed to eigsh. 0 means machine
+        precision. Default: 0.
+    :type tol: float
+    :param include_eig_val: When True (and include_eig is False), return a pair (DataFrame, eigen values)
+        instead of just the DataFrame. Default: False.
+    :type include_eig_val: bool
     :return: A pandas.DataFrame with a row per individual and a column per principal component. Or, if include_eig
         then a triple (dataframe, eigen values, eigen vectors), where eigen vectors are None unless use_pro_pca
         was True.
@@ -308,6 +331,8 @@ def PCs(
             threads=threads,
             op_kwargs={"mutation_filter": mutation_filter},
             do_xtx=include_eig,
+            init_vector=init_vector,
+            tol=tol,
         )
 
     colnames = [f"PC{i+1}" for i in range(PC_scores.shape[1])]
@@ -315,4 +340,6 @@ def PCs(
     df.index.name = "Individual"
     if include_eig:
         return df, eigen_values, eigen_vectors
+    if include_eig_val:
+        return df, eigen_values
     return df

--- a/grapp/linalg/ops_cupy.py
+++ b/grapp/linalg/ops_cupy.py
@@ -255,8 +255,11 @@ class CuPyXOperator(LinearOperator):
                     kwargs["miss"] = M
 
                 with cuda.Device(self._device):
-                    result = self.grg.matmul(
-                        A, mult_dir, by_individual=not self.haploid, **kwargs
+                    result = self.grg.get_raw().matmul(
+                        A,
+                        self.grg._convert_dir(mult_dir),
+                        by_individual=not self.haploid,
+                        **kwargs,
                     )
 
                 if mult_dir == _UP and use_M:
@@ -505,8 +508,10 @@ class CuPyStdXOperator(_CuPyStandardizedOperator):
 
                     with _nvtx("StdX_matmul"):
                         with cuda.Device(self._device):
-                            XvS = self.grg.matmul(
-                                vS, mult_dir, by_individual=not self.haploid
+                            XvS = self.grg.get_raw().matmul(
+                                vS,
+                                self.grg._convert_dir(mult_dir),
+                                by_individual=not self.haploid,
                             )
                             xp.cuda.get_current_stream().synchronize()
 
@@ -525,8 +530,10 @@ class CuPyStdXOperator(_CuPyStandardizedOperator):
                         # See UP branch: re-assert self._device around the native
                         # matmul so the post-matmul math stays on the right device.
                         with cuda.Device(self._device):
-                            SXv_raw = self.grg.matmul(
-                                m, mult_dir, by_individual=not self.haploid
+                            SXv_raw = self.grg.get_raw().matmul(
+                                m,
+                                self.grg._convert_dir(mult_dir),
+                                by_individual=not self.haploid,
                             )
                             xp.cuda.get_current_stream().synchronize()
                             SXv = SXv_raw * self.inverse_sigma

--- a/grapp/linalg/ops_cupy.py
+++ b/grapp/linalg/ops_cupy.py
@@ -1,0 +1,1224 @@
+"""
+CuPy-native linear operators for Spmv-GRG matrix multiplications.
+
+All operators require a CUDA-capable GRG (grg.device must not be None).
+CuPy is a hard dependency; an ImportError at import time indicates it is
+not installed.
+
+Memory model
+------------
+For single-GRG operators, the input and output buffers are assumed to be 
+on the GRG's device. For multi-GRG operators, the input and output buffers 
+are assumed to be on the "primary device", which should be the device of 
+the first GRG.
+
+Stream model
+------------
+All operations are expected to perform on or sync with the default stream
+of the corresponding GRG's device.
+"""
+
+import cupy as xp
+from cupy import cuda
+from contextlib import contextmanager
+from cupyx.scipy.sparse.linalg import LinearOperator
+from pygrgl import TraversalDirection
+from typing import List, Optional, Tuple, Union
+import numpy
+
+from grapp.grg_calculator import (
+    GRGCalcInterface as _GRGCalcInterface,
+    _wrap_grg,
+)
+
+
+# When True, cross-device copies are routed D2H + H2D instead of using
+# cudaMemcpyPeer / NVLink.  Set before any operator _matmat call to benchmark
+# PCIe-only transfers.
+force_host_xdev_copy: bool = False
+
+_DOWN = TraversalDirection.DOWN
+_UP = TraversalDirection.UP
+
+
+def _flip_dir(direction: TraversalDirection) -> TraversalDirection:
+    return _UP if direction == _DOWN else _DOWN
+
+def _transpose_shape(shape: Tuple[int, int]) -> Tuple[int, int]:
+    return (shape[1], shape[0])
+
+# ---------------------------------------------------------------------------
+# NVTX helper
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def _nvtx(name: str):
+    """Context manager that always pops an NVTX range, even on exception."""
+    xp.cuda.nvtx.RangePush(name)
+    try:
+        yield
+    finally:
+        xp.cuda.nvtx.RangePop()
+
+
+# ---------------------------------------------------------------------------
+# Cross-device helpers
+# ---------------------------------------------------------------------------
+
+def _xdev_copy(dst, src) -> None:
+    """Write src into dst, routing through host when force_host_xdev_copy is set.
+
+    When copying across devices, the source device's current stream is
+    synchronized first so that all kernels producing src are guaranteed
+    complete before the D2D transfer begins.
+    """
+    if force_host_xdev_copy:
+        with cuda.Device(dst.device):
+            dst[:] = xp.asarray(src.get())
+    else:
+        if hasattr(src, "device") and hasattr(dst, "device") and src.device != dst.device:
+            with cuda.Device(src.device):
+                xp.cuda.get_current_stream().synchronize()
+        with cuda.Device(dst.device):
+            dst[:] = src
+            xp.cuda.get_current_stream().synchronize()
+
+
+def _xdev_asarray(src):
+    """Return src as a CuPy array on the current device, copying if necessary.
+    """
+    if force_host_xdev_copy and hasattr(src, "get"):
+        return xp.asarray(src.get())
+    dev = getattr(src, "device", None)
+
+    if dev is not None and hasattr(dev, "id") and dev.id != xp.cuda.Device().id:
+        with cuda.Device(dev):
+            src = xp.ascontiguousarray(src)
+            xp.cuda.get_current_stream().synchronize()
+        return xp.array(src)  # explicit D2D copy to current device
+    return xp.asarray(src)
+
+
+# ---------------------------------------------------------------------------
+# GRGOpFilter
+# ---------------------------------------------------------------------------
+
+class GRGOpFilter:
+    """Handles optional mutation and sample sub-selection for GRG operators."""
+
+    def __init__(
+        self,
+        grg: "_GRGCalcInterface",
+        haploid: bool,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray, "xp.ndarray"]],
+        sample_filter: Optional[Union[List[int], numpy.ndarray, "xp.ndarray"]],
+    ):
+        if mutation_filter is not None:
+            if isinstance(mutation_filter, (numpy.ndarray, xp.ndarray)):
+                mutation_filter = mutation_filter.tolist()
+            assert len(set(mutation_filter)) == len(
+                mutation_filter
+            ), "Duplicate IDs in mutation_filter"
+        self.mutation_filter = mutation_filter
+
+        if sample_filter is not None:
+            if isinstance(sample_filter, (numpy.ndarray, xp.ndarray)):
+                sample_filter = sample_filter.tolist()
+            assert len(set(sample_filter)) == len(
+                sample_filter
+            ), "Duplicate IDs in sample_filter"
+        self.sample_filter = sample_filter
+
+        sample_count = grg.num_samples if haploid else grg.num_individuals
+        self.grg_shape = (sample_count, grg.num_mutations)
+        self.shape = (
+            self.grg_shape[0] if sample_filter is None else len(sample_filter),
+            self.grg_shape[1] if mutation_filter is None else len(mutation_filter),
+        )
+        self.is_filtering = self.sample_filter is not None or self.mutation_filter is not None
+        self._device = getattr(grg, "device", None)
+
+    def prep_input(self, input_matrix, mult_dir: TraversalDirection):
+        """Zero-pad input_matrix to the full GRG dimension, scattering filtered indices."""
+        if mult_dir == _DOWN:
+            if self.mutation_filter is not None:
+                with cuda.Device(self._device):
+                    new_matrix = xp.zeros(
+                        (input_matrix.shape[0], self.grg_shape[1]),
+                        dtype=input_matrix.dtype,
+                    )
+                    new_matrix[:, self.mutation_filter] = input_matrix
+                return new_matrix
+        else:
+            assert mult_dir == _UP
+            if self.sample_filter is not None:
+                with cuda.Device(self._device):
+                    new_matrix = xp.zeros(
+                        (input_matrix.shape[0], self.grg_shape[0]),
+                        dtype=input_matrix.dtype,
+                    )
+                    new_matrix[:, self.sample_filter] = input_matrix
+                return new_matrix
+        return input_matrix
+
+    def adjust_output(self, output_matrix, mult_dir: TraversalDirection):
+        """Select only the filtered indices from the output matrix."""
+        if mult_dir == _UP:
+            if self.mutation_filter is not None:
+                return output_matrix[:, self.mutation_filter]
+        else:
+            assert mult_dir == _DOWN
+            if self.sample_filter is not None:
+                return output_matrix[:, self.sample_filter]
+        return output_matrix
+
+
+# ---------------------------------------------------------------------------
+# Non-standardized operators
+# ---------------------------------------------------------------------------
+
+
+class CuPyXOperator(LinearOperator):
+    """
+    LinearOperator on the genotype matrix X (NxM) or its transpose X^T (MxN).
+
+    direction=UP   → shape (N, M), _matmat computes X @ A
+    direction=DOWN → shape (M, N), _matmat computes X^T @ A
+
+    :param grg: The GRG to multiply against. Must expose a `device` attribute.
+    :param direction: Selects X (UP) or X^T (DOWN).
+    :param dtype: Output dtype.
+    :param haploid: When True use {0,1} haploid matrix; otherwise {0..ploidy}.
+    :param miss_values: 1-D vector of per-mutation imputation values for
+        missing data. Ignored when the GRG has no missing data.
+    :param mutation_filter: Subset of mutation IDs to expose; shapes X to NxP.
+    :param sample_filter: Subset of sample IDs to expose; shapes X to QxM.
+    """
+
+    def __init__(
+        self,
+        grg: _GRGCalcInterface,
+        direction: TraversalDirection,
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        miss_values: Optional[numpy.ndarray] = None,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+    ):
+        self.grg = _wrap_grg(grg)
+        self._device = getattr(self.grg, "device", None)
+        if self._device is None:
+            raise ValueError(
+                "CuPyXOperator requires grg.device to be set (not None). "
+                "Use a GPU-backed GRG such as GRGSpMVCalculator."
+            )
+        self.filter = GRGOpFilter(self.grg, haploid, mutation_filter, sample_filter)
+        self.haploid = haploid
+        self.direction = direction
+        assert (
+            miss_values is None or miss_values.ndim == 1
+        ), '"miss_values" must be a 1-D vector'
+        with cuda.Device(self._device):
+            self.miss_values = xp.asarray(miss_values) if miss_values is not None else None
+        shape = self.filter.shape
+        if self.direction == _DOWN:
+            shape = _transpose_shape(shape)
+        super().__init__(dtype=dtype, shape=shape)
+
+    def _matmat_helper(self, other_matrix, mult_dir: TraversalDirection, out=None):
+        label = "UP" if mult_dir == _UP else "DOWN"
+        with _nvtx(f"XOp_{label}"):
+            with cuda.Device(self._device):
+                # Move input to self._device; no-op if already there.
+                A = self.filter.prep_input(_xdev_asarray(other_matrix).T, mult_dir)
+
+                kwargs = {}
+                use_M = self.grg.has_missing_data and self.miss_values is not None
+                if use_M:
+                    if mult_dir == _DOWN:
+                        M = xp.array([self.miss_values]) * A
+                    else:
+                        M = xp.zeros(
+                            (A.shape[0], self.grg.num_mutations), dtype=self.dtype
+                        )
+                    kwargs["miss"] = M
+
+                with cuda.Device(self._device):
+                    result = self.grg.matmul(
+                        A, mult_dir, by_individual=not self.haploid, **kwargs
+                    )
+
+                if mult_dir == _UP and use_M:
+                    result += M * self.miss_values
+
+                result = self.filter.adjust_output(result, mult_dir).T
+
+                if out is not None:
+                    # Sync self._device stream; queue copy on out.device's null stream.
+                    _xdev_copy(out, result)
+                    return out
+            return result
+
+    def _matmat(self, other_matrix, out=None):
+        return self._matmat_helper(other_matrix, _flip_dir(self.direction), out)
+
+    def _rmatmat(self, other_matrix, out=None):
+        return self._matmat_helper(other_matrix, self.direction, out)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class CuPyXTXOperator(LinearOperator):
+    """LinearOperator for X^T X (MxM non-centred correlation matrix)."""
+
+    def __init__(
+        self,
+        grg: _GRGCalcInterface,
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        miss_values: Optional[numpy.ndarray] = None,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+    ):
+        self.x_op = CuPyXOperator(
+            grg, _UP, dtype=dtype, haploid=haploid, miss_values=miss_values,
+            mutation_filter=mutation_filter, sample_filter=sample_filter,
+        )
+        self._device = self.x_op._device
+        super().__init__(dtype=dtype, shape=(self.x_op.shape[1], self.x_op.shape[1]))
+
+    def _matmat(self, other_matrix):
+        with _nvtx("XTXOp_matmat"):
+            D = self.x_op._matmat(other_matrix)
+            return self.x_op._rmatmat(D)
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat(other_matrix)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class CuPyXXTOperator(LinearOperator):
+    """LinearOperator for X X^T (NxN genetic relatedness matrix)."""
+
+    def __init__(
+        self,
+        grg: _GRGCalcInterface,
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        miss_values: Optional[numpy.ndarray] = None,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+    ):
+        self.x_op = CuPyXOperator(
+            grg, _UP, dtype=dtype, haploid=haploid, miss_values=miss_values,
+            mutation_filter=mutation_filter, sample_filter=sample_filter,
+        )
+        self._device = self.x_op._device
+        self.grg = self.x_op.grg
+        super().__init__(dtype=dtype, shape=(self.x_op.shape[0], self.x_op.shape[0]))
+
+    def _matmat(self, other_matrix, out=None):
+        with _nvtx("XXTOp_matmat"):
+            D = self.x_op._rmatmat(other_matrix)
+            result = self.x_op._matmat(D)
+            if out is not None:
+                _xdev_copy(out, result)
+                return out
+            return result
+
+    def _rmatmat(self, other_matrix, out=None):
+        return self._matmat(other_matrix, out)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+# ---------------------------------------------------------------------------
+# Standardized operators
+# ---------------------------------------------------------------------------
+
+class _CuPyStandardizedOperator(LinearOperator):
+    """
+    Base class that pre-computes and stores allele-frequency-derived scalings
+    on the GRG's device.
+
+    Scaling: inverse_sigma[i] = sqrt(variance[i]^alpha), where variance is
+    binomial by default (mult_const * freq * (1-freq)).  Entries where
+    variance == 0 (fixed alleles) remain 0 to avoid NaN.
+
+    :param freqs: 1-D allele frequency vector of length M.
+    :param alpha: Power applied to variance; default -1 gives 1/sigma scaling.
+    :param custom_variance: Replace binomial variance with caller-supplied values.
+    """
+
+    def __init__(
+        self,
+        grg: _GRGCalcInterface,
+        freqs: numpy.ndarray,
+        shape: Tuple[int, int],
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        alpha: float = -1,
+        custom_variance: Optional[numpy.ndarray] = None,
+    ):
+        self.haploid = haploid
+        self.grg = _wrap_grg(grg)
+        self._device = getattr(self.grg, "device", None)
+        if self._device is None:
+            raise ValueError(
+                "Standardized CuPy operators require grg.device to be set (not None)."
+            )
+        self.mult_const = 1 if haploid else self.grg.ploidy
+
+        with cuda.Device(self._device):
+            self.freqs = xp.asarray(freqs)
+            if custom_variance is not None:
+                assert (
+                    custom_variance.shape == freqs.shape
+                ), "custom_variance must have the same shape as freqs"
+                variance = xp.asarray(custom_variance)
+            else:
+                variance = self.mult_const * self.freqs * (1.0 - self.freqs)
+
+            mask = variance != 0
+            self.inverse_sigma = xp.zeros(variance.shape, dtype=variance.dtype)
+            self.inverse_sigma[mask] = xp.sqrt(xp.power(variance[mask], alpha))
+
+        super().__init__(dtype=dtype, shape=shape)
+
+
+class CuPyStdXOperator(_CuPyStandardizedOperator):
+    """
+    LinearOperator on the standardized genotype matrix X or X^T.
+
+    Standardization centers each column by its mean (mult_const * freq) and
+    scales by 1/sigma, where sigma = sqrt(variance^alpha).
+
+    direction=UP   → shape (N, M), _matmat computes stdX @ A
+    direction=DOWN → shape (M, N), _matmat computes stdX^T @ A
+
+    :param direction: Selects standardized X (UP) or its transpose (DOWN).
+    :param freqs: Per-mutation allele frequencies, shape (M,).
+    :param mutation_filter: Subset of mutation IDs; shapes X to NxP.
+    :param sample_filter: Subset of sample IDs; shapes X to QxM.
+    :param alpha: See _CuPyStandardizedOperator.
+    :param custom_variance: See _CuPyStandardizedOperator.
+    """
+
+    def __init__(
+        self,
+        grg: _GRGCalcInterface,
+        direction: TraversalDirection,
+        freqs: numpy.ndarray,
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        alpha: float = -1,
+        custom_variance: Optional[numpy.ndarray] = None,
+    ):
+        self.filter = GRGOpFilter(_wrap_grg(grg), haploid, mutation_filter, sample_filter)
+        self.direction = direction
+        shape = self.filter.shape
+        if self.direction == _DOWN:
+            shape = _transpose_shape(shape)
+        super().__init__(
+            grg, freqs, shape, dtype=dtype, haploid=haploid,
+            alpha=alpha, custom_variance=custom_variance,
+        )
+
+    def _matmat_direction(self, other_matrix, direction: TraversalDirection, out=None):
+        label = "UP" if direction == _UP else "DOWN"
+        with _nvtx(f"StdXOp_{label}"):
+            with cuda.Device(self._device):
+                # Move input to self._device; no-op if already there.
+                other_matrix = _xdev_asarray(other_matrix)
+                mult_dir = _flip_dir(direction)
+
+                if direction == _UP:
+                    with _nvtx("StdX_prep_scale"):
+                        # prep_input allocates on self._device (inside _device_ctx).
+                        # inverse_sigma and freqs are on self._device.
+                        vS = (
+                            self.filter.prep_input(other_matrix.T, mult_dir)
+                            * self.inverse_sigma
+                        )
+
+                    with _nvtx("StdX_matmul"):
+                        with cuda.Device(self._device):
+                            XvS = self.grg.matmul(
+                                vS, mult_dir, by_individual=not self.haploid
+                            )
+                            xp.cuda.get_current_stream().synchronize()
+
+                    with _nvtx("StdX_post"):
+                        with cuda.Device(self._device):
+                            consts = xp.sum(
+                                self.mult_const * self.freqs * vS, axis=1, keepdims=True
+                            )
+                            result = self.filter.adjust_output(XvS - consts, mult_dir).T
+
+                else:  # DOWN
+                    with _nvtx("StdX_prep"):
+                        m = self.filter.prep_input(other_matrix.T, mult_dir)
+
+                    with _nvtx("StdX_matmul"):
+                        # See UP branch: re-assert self._device around the native
+                        # matmul so the post-matmul math stays on the right device.
+                        with cuda.Device(self._device):
+                            SXv_raw = self.grg.matmul(
+                                m, mult_dir, by_individual=not self.haploid
+                            )
+                            xp.cuda.get_current_stream().synchronize()
+                            SXv = SXv_raw * self.inverse_sigma
+
+                    with _nvtx("StdX_post"):
+                        with cuda.Device(self._device):
+                            col_const = xp.sum(m.T, axis=0, keepdims=True).T
+                            sub_const2 = (
+                                self.mult_const * self.freqs * self.inverse_sigma
+                            ) * col_const
+                            result = self.filter.adjust_output(SXv - sub_const2, mult_dir).T
+
+                if out is not None:
+                    # Sync self._device stream; queue copy on out.device's null stream.
+                    _xdev_copy(out, result)
+                    return out
+            return result
+
+    def _matmat(self, other_matrix, out=None):
+        return self._matmat_direction(other_matrix, self.direction, out)
+
+    def _rmatmat(self, other_matrix, out=None):
+        return self._matmat_direction(other_matrix, _flip_dir(self.direction), out)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class CuPyStdXTXOperator(LinearOperator):
+    """LinearOperator for the standardized X^T X (MxM correlation matrix)."""
+
+    def __init__(
+        self,
+        grg: _GRGCalcInterface,
+        freqs: numpy.ndarray,
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        alpha: float = -1,
+        custom_variance: Optional[numpy.ndarray] = None,
+    ):
+        self.std_x_op = CuPyStdXOperator(
+            grg, _UP, freqs, dtype=dtype, haploid=haploid,
+            mutation_filter=mutation_filter, sample_filter=sample_filter,
+            alpha=alpha, custom_variance=custom_variance,
+        )
+        self._device = self.std_x_op._device
+        super().__init__(
+            dtype=dtype, shape=(self.std_x_op.shape[1], self.std_x_op.shape[1])
+        )
+
+    def _matmat(self, other_matrix):
+        with _nvtx("StdXTXOp_matmat"):
+            D = self.std_x_op._matmat(other_matrix)
+            return self.std_x_op._rmatmat(D)
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat(other_matrix)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class CuPyStdXXTOperator(LinearOperator):
+    """LinearOperator for the standardized X X^T (NxN genetic relatedness matrix)."""
+
+    def __init__(
+        self,
+        grg: _GRGCalcInterface,
+        freqs: numpy.ndarray,
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        alpha: float = -1,
+        custom_variance: Optional[numpy.ndarray] = None,
+    ):
+        self.std_x_op = CuPyStdXOperator(
+            grg, _UP, freqs, dtype=dtype, haploid=haploid,
+            mutation_filter=mutation_filter, sample_filter=sample_filter,
+            alpha=alpha, custom_variance=custom_variance,
+        )
+        self._device = self.std_x_op._device
+        self.grg = self.std_x_op.grg
+        super().__init__(
+            dtype=dtype, shape=(self.std_x_op.shape[0], self.std_x_op.shape[0])
+        )
+
+    def _matmat(self, other_matrix, out=None):
+        with _nvtx("StdXXTOp_matmat"):
+            D = self.std_x_op._rmatmat(other_matrix)
+            result = self.std_x_op._matmat(D)
+            if out is not None:
+                _xdev_copy(out, result)
+                return out
+            return result
+
+    def _rmatmat(self, other_matrix, out=None):
+        return self._matmat(other_matrix, out)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+# ---------------------------------------------------------------------------
+# Multi-GRG operators
+# ---------------------------------------------------------------------------
+
+def _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g):
+    """Remap global mutation_filter indices to per-GRG local indices."""
+    if mutation_filter is None:
+        return None, False
+    grg_mut_filt = list(
+        map(
+            lambda m: m - prev_max_mut,
+            filter(
+                lambda m: m >= prev_max_mut and m < prev_max_mut + g.num_mutations,
+                mutation_filter,
+            ),
+        )
+    )
+    return grg_mut_filt, len(grg_mut_filt) == 0
+
+
+class MultiCuPyXOperator(LinearOperator):
+    """
+    LinearOperator on multiple GRGs. If GRGs have mutation counts M1, M2, ...,
+    the implicit genotype matrix has dimensions Nx(M1+M2+...).
+
+    :param grgs: GRGs with the same samples (e.g., one per chromosome).
+    :param direction: UP -> X (NxM); DOWN -> X^T (MxN).
+    :param dtype: Output dtype.
+    :param haploid: Use {0,1} haploid matrix.
+    :param miss_values: Per-mutation imputation vector (all GRGs concatenated).
+    :param mutation_filter: Global mutation indices to expose; remapped per GRG.
+    :param sample_filter: Sample indices to expose; applied to all GRGs.
+    :param threads: Thread-pool size for parallelising across GRGs.
+    """
+
+    def __init__(
+        self,
+        grgs: List[_GRGCalcInterface],
+        direction: TraversalDirection,
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        miss_values: Optional[numpy.ndarray] = None,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        threads: int = 1,
+    ):
+        assert len(grgs) >= 1, "Must provide at least one GRG"
+        self.direction = direction
+        self.operators: List[CuPyXOperator] = []
+        prev_miss_start = 0
+        prev_max_mut = 0
+        for g in grgs:
+            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
+            if not skip:
+                effective_muts = len(grg_mut_filt) if grg_mut_filt is not None else g.num_mutations
+                if miss_values is not None:
+                    grg_miss = miss_values[prev_miss_start:prev_miss_start + effective_muts]
+                    prev_miss_start += effective_muts
+                else:
+                    grg_miss = None
+                self.operators.append(
+                    CuPyXOperator(
+                        g, direction, dtype, haploid=haploid,
+                        miss_values=grg_miss,
+                        mutation_filter=grg_mut_filt,
+                        sample_filter=sample_filter,
+                    )
+                )
+            prev_max_mut += g.num_mutations
+        self._output_device = self.operators[0]._device
+        self.scheduler = _wrap_grg(grgs[0]).make_scheduler(grgs, threads)
+        if direction == _UP:
+            shape = (self.operators[0].shape[0], sum(op.shape[1] for op in self.operators))
+        else:
+            shape = (sum(op.shape[0] for op in self.operators), self.operators[0].shape[1])
+        super().__init__(dtype=dtype, shape=shape)
+
+    def _matmat_helper(self, other_matrix, direction, op_method):
+        k = other_matrix.shape[1]
+        label = "UP" if direction == _UP else "DOWN"
+        futures = []
+        with _nvtx(f"MultiXOp_{label}"):
+            if direction == _UP:
+                # Reduce branch: split the input along each GRG's mutation axis
+                # and sum the per-GRG sample-space outputs. The mutation/sample
+                # axes of each sub-operator depend on self.direction (UP exposes
+                # shape (N, M_i); DOWN exposes shape (M_i, N)).
+                op_muts = (
+                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    else (lambda op: op.shape[1])
+                )
+                n_rows = (
+                    self.operators[0].shape[1] if self.direction == _DOWN
+                    else self.operators[0].shape[0]
+                )
+                parts = []
+                for _ in self.operators:
+                    with cuda.Device(self._output_device):
+                        parts.append(xp.empty((n_rows, k), dtype=self.dtype))
+                start = 0
+                for op, part in zip(self.operators, parts):
+                    end = start + op_muts(op)
+                    sub = other_matrix[start:end, :]
+                    with cuda.Device(op._device):
+                        sub = _xdev_asarray(sub)
+                    futures.append(self.scheduler.submit(op.grg, op_method, op, sub, part))
+                    start = end
+                returned_parts = []
+                for f in futures:
+                    returned_parts.append(f.result())
+                with cuda.Device(self._output_device):
+                    xp.cuda.get_current_stream().synchronize()
+                    result = sum(returned_parts[1:], returned_parts[0])
+                    # Sync so that sum kernels complete before any cross-device read of result.
+                    xp.cuda.get_current_stream().synchronize()
+                return result
+            else:
+                # Each op gets the full input; outputs are concatenated.
+                op_rows = (
+                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    else (lambda op: op.shape[1])
+                )
+                total_rows = sum(op_rows(op) for op in self.operators)
+                with cuda.Device(self._output_device):
+                    output = xp.empty((total_rows, k), dtype=self.dtype)
+                start = 0
+                for op in self.operators:
+                    end = start + op_rows(op)
+                    out_slice = output[start:end, :]
+                    with cuda.Device(op._device):
+                        op_input = _xdev_asarray(other_matrix)
+                    futures.append(
+                        self.scheduler.submit(op.grg, op_method, op, op_input, out_slice)
+                    )
+                    start = end
+                for f in futures:
+                    f.result()
+                # Sync so that in-flight D2D copies to output complete before any
+                # cross-device read of output (e.g. by the XTX DOWN pass).
+                with cuda.Device(self._output_device):
+                    xp.cuda.get_current_stream().synchronize()
+                return output
+
+    def _matmat(self, other_matrix):
+        return self._matmat_helper(other_matrix, self.direction, CuPyXOperator._matmat)
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat_helper(
+            other_matrix, _flip_dir(self.direction), CuPyXOperator._rmatmat
+        )
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class MultiCuPyXTXOperator(LinearOperator):
+    """
+    LinearOperator for X^T X across multiple GRGs (MxM, symmetric).
+    Equivalent to CuPyXTXOperator but across a list of GRGs sharing the same samples.
+    """
+
+    def __init__(
+        self,
+        grgs: List[_GRGCalcInterface],
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        miss_values: Optional[numpy.ndarray] = None,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        threads: int = 1,
+    ):
+        self.x_op = MultiCuPyXOperator(
+            grgs, _UP, dtype=dtype, haploid=haploid,
+            miss_values=miss_values,
+            mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
+            threads=threads,
+        )
+        self._output_device = self.x_op._output_device
+        super().__init__(dtype=dtype, shape=(self.x_op.shape[1], self.x_op.shape[1]))
+
+    def _matmat(self, other_matrix):
+        with _nvtx("MultiXTXOp_matmat"):
+            D = self.x_op._matmat(other_matrix)
+            return self.x_op._rmatmat(D)
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat(other_matrix)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class MultiCuPyXXTOperator(LinearOperator):
+    """
+    LinearOperator for X X^T across multiple GRGs (NxN, symmetric).
+
+    Dispatches to one CuPyXXTOperator per GRG and sums N*K results on
+    _output_device, costing 2 D2D copies per GRG (broadcast input + gather
+    result) instead of 4 (the old Multi-X approach required an intermediate
+    M*K transfer in each direction).
+    """
+
+    def __init__(
+        self,
+        grgs: List[_GRGCalcInterface],
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        miss_values: Optional[numpy.ndarray] = None,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        threads: int = 1,
+    ):
+        assert len(grgs) >= 1, "Must provide at least one GRG"
+        self.operators: List[CuPyXXTOperator] = []
+        prev_miss_start = 0
+        prev_max_mut = 0
+        for g in grgs:
+            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
+            if not skip:
+                effective_muts = len(grg_mut_filt) if grg_mut_filt is not None else g.num_mutations
+                if miss_values is not None:
+                    grg_miss = miss_values[prev_miss_start:prev_miss_start + effective_muts]
+                    prev_miss_start += effective_muts
+                else:
+                    grg_miss = None
+                self.operators.append(
+                    CuPyXXTOperator(
+                        g, dtype, haploid=haploid,
+                        miss_values=grg_miss,
+                        mutation_filter=grg_mut_filt,
+                        sample_filter=sample_filter,
+                    )
+                )
+            prev_max_mut += g.num_mutations
+        self._output_device = self.operators[0]._device
+        self.scheduler = _wrap_grg(grgs[0]).make_scheduler(grgs, threads)
+        n = self.operators[0].shape[0]
+        super().__init__(dtype=dtype, shape=(n, n))
+
+    def _matmat(self, other_matrix):
+        n, k = self.shape[0], other_matrix.shape[1]
+        futures = []
+        with _nvtx("MultiXXTOp_matmat"):
+            parts = []
+            for _ in self.operators:
+                with cuda.Device(self._output_device):
+                    parts.append(xp.empty((n, k), dtype=self.dtype))
+            for op, part in zip(self.operators, parts):
+                futures.append(
+                    self.scheduler.submit(
+                        op.grg, CuPyXXTOperator._matmat, op, other_matrix, part
+                    )
+                )
+            for f in futures:
+                f.result()
+            with cuda.Device(self._output_device):
+                result = sum(parts[1:], parts[0])
+                xp.cuda.get_current_stream().synchronize()
+            return result
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat(other_matrix)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class MultiCuPyStdXOperator(LinearOperator):
+    """
+    LinearOperator on the standardized genotype matrix across multiple GRGs.
+
+    :param grgs: GRGs sharing the same samples.
+    :param direction: UP -> stdX; DOWN -> stdX^T.
+    :param freqs: List of per-GRG allele-frequency arrays (one per GRG).
+    :param mutation_filter: Global mutation indices; remapped per GRG.
+    :param threads: Thread-pool size.
+    :param alpha: Variance power; default -1 gives 1/sigma scaling.
+    :param custom_variance: Custom variance. Can be a single array of length num_mutations
+        (applied to all GRGs) or a list of per-GRG arrays.
+    """
+
+    def __init__(
+        self,
+        grgs: List[_GRGCalcInterface],
+        direction: TraversalDirection,
+        freqs: List[numpy.ndarray],
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        threads: int = 1,
+        alpha: float = -1,
+        custom_variance: Optional[Union[numpy.ndarray, List[numpy.ndarray]]] = None,
+    ):
+        assert len(grgs) >= 1, "Must provide at least one GRG"
+        assert len(grgs) == len(freqs), "Must provide allele frequencies for every GRG"
+        if isinstance(custom_variance, list):
+            assert len(custom_variance) == len(grgs), "custom_variance list must have one entry per GRG"
+        self.direction = direction
+        self.operators: List[CuPyStdXOperator] = []
+        prev_max_mut = 0
+        for i, (g, f) in enumerate(zip(grgs, freqs)):
+            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
+            grg_custom_var = custom_variance[i] if isinstance(custom_variance, list) else custom_variance
+            if not skip:
+                self.operators.append(
+                    CuPyStdXOperator(
+                        g, direction, f, dtype, haploid=haploid,
+                        mutation_filter=grg_mut_filt,
+                        sample_filter=sample_filter,
+                        alpha=alpha,
+                        custom_variance=grg_custom_var,
+                    )
+                )
+            prev_max_mut += g.num_mutations
+        self._output_device = self.operators[0]._device
+        self.scheduler = _wrap_grg(grgs[0]).make_scheduler(grgs, threads)
+        if direction == _UP:
+            shape = (self.operators[0].shape[0], sum(op.shape[1] for op in self.operators))
+        else:
+            shape = (sum(op.shape[0] for op in self.operators), self.operators[0].shape[1])
+        super().__init__(dtype=dtype, shape=shape)
+
+    def _matmat_helper(self, other_matrix, direction, op_method):
+        k = other_matrix.shape[1]
+        label = "UP" if direction == _UP else "DOWN"
+        futures = []
+        with _nvtx(f"MultiStdXOp_{label}"):
+            if direction == _UP:
+                # Reduce branch: split the input along each GRG's mutation axis
+                # and sum the per-GRG sample-space outputs. The mutation/sample
+                # axes of each sub-operator depend on self.direction (UP exposes
+                # shape (N, M_i); DOWN exposes shape (M_i, N)).
+                op_muts = (
+                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    else (lambda op: op.shape[1])
+                )
+                n_rows = (
+                    self.operators[0].shape[1] if self.direction == _DOWN
+                    else self.operators[0].shape[0]
+                )
+                parts = []
+                for _ in self.operators:
+                    with cuda.Device(self._output_device):
+                        parts.append(xp.empty((n_rows, k), dtype=self.dtype))
+                start = 0
+                for op, part in zip(self.operators, parts):
+                    end = start + op_muts(op)
+                    sub = other_matrix[start:end, :]
+                    with cuda.Device(op._device):
+                        sub = _xdev_asarray(sub)
+                    futures.append(self.scheduler.submit(op.grg, op_method, op, sub, part))
+                    start = end
+                for f in futures:
+                    f.result()
+                with cuda.Device(self._output_device):
+                    result = sum(parts[1:], parts[0])
+                    xp.cuda.get_current_stream().synchronize()
+                return result
+            else:
+                op_rows = (
+                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    else (lambda op: op.shape[1])
+                )
+                total_rows = sum(op_rows(op) for op in self.operators)
+                with cuda.Device(self._output_device):
+                    output = xp.empty((total_rows, k), dtype=self.dtype)
+                start = 0
+                for op in self.operators:
+                    end = start + op_rows(op)
+                    out_slice = output[start:end, :]
+                    with cuda.Device(op._device):
+                        op_input = _xdev_asarray(other_matrix)
+                    futures.append(
+                        self.scheduler.submit(op.grg, op_method, op, op_input, out_slice)
+                    )
+                    start = end
+                for f in futures:
+                    f.result()
+                with cuda.Device(self._output_device):
+                    xp.cuda.get_current_stream().synchronize()
+                return output
+
+    def _matmat(self, other_matrix):
+        return self._matmat_helper(other_matrix, self.direction, CuPyStdXOperator._matmat)
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat_helper(
+            other_matrix, _flip_dir(self.direction), CuPyStdXOperator._rmatmat
+        )
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class MultiCuPyStdXTXOperator(LinearOperator):
+    """
+    LinearOperator for standardized X^T X across multiple GRGs (MxM, symmetric).
+    """
+
+    def __init__(
+        self,
+        grgs: List[_GRGCalcInterface],
+        freqs: List[numpy.ndarray],
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        threads: int = 1,
+        alpha: float = -1,
+        custom_variance: Optional[numpy.ndarray] = None,
+    ):
+        self.std_x_op = MultiCuPyStdXOperator(
+            grgs, _UP, freqs, dtype=dtype, haploid=haploid,
+            mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
+            threads=threads,
+            alpha=alpha,
+            custom_variance=custom_variance,
+        )
+        self._output_device = self.std_x_op._output_device
+        super().__init__(
+            dtype=dtype, shape=(self.std_x_op.shape[1], self.std_x_op.shape[1])
+        )
+
+    def _matmat(self, other_matrix):
+        with _nvtx("MultiStdXTXOp_matmat"):
+            D = self.std_x_op._matmat(other_matrix)
+            return self.std_x_op._rmatmat(D)
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat(other_matrix)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+
+class MultiCuPyStdXXTOperator(LinearOperator):
+    """
+    LinearOperator for standardized X X^T across multiple GRGs (NxN, symmetric).
+
+    Uses one CuPyStdXXTOperator per GRG and sums results on _output_device,
+    costing 2 D2D copies per GRG instead of 4 (see MultiCuPyXXTOperator).
+
+    :param freqs: List of per-GRG allele-frequency arrays.
+    :param custom_variance: Per-GRG custom variance. Can be a single array of length
+        num_mutations (applied to all GRGs) or a list of per-GRG arrays.
+    """
+
+    def __init__(
+        self,
+        grgs: List[_GRGCalcInterface],
+        freqs: List[numpy.ndarray],
+        dtype: numpy.typing.DTypeLike = numpy.float64,
+        haploid: bool = False,
+        mutation_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
+        threads: int = 1,
+        alpha: float = -1,
+        custom_variance: Optional[Union[numpy.ndarray, List[numpy.ndarray]]] = None,
+    ):
+        assert len(grgs) >= 1, "Must provide at least one GRG"
+        assert len(grgs) == len(freqs), "Must provide allele frequencies for every GRG"
+        if isinstance(custom_variance, list):
+            assert len(custom_variance) == len(grgs), "custom_variance list must have one entry per GRG"
+        self.operators: List[CuPyStdXXTOperator] = []
+        prev_max_mut = 0
+        for i, (g, f) in enumerate(zip(grgs, freqs)):
+            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
+            grg_custom_var = custom_variance[i] if isinstance(custom_variance, list) else custom_variance
+            if not skip:
+                self.operators.append(
+                    CuPyStdXXTOperator(
+                        g, f, dtype, haploid=haploid,
+                        mutation_filter=grg_mut_filt,
+                        sample_filter=sample_filter,
+                        alpha=alpha,
+                        custom_variance=grg_custom_var,
+                    )
+                )
+            prev_max_mut += g.num_mutations
+        self._output_device = self.operators[0]._device
+        self.scheduler = _wrap_grg(grgs[0]).make_scheduler(grgs, threads, gated=True)
+        n = self.operators[0].shape[0]
+        super().__init__(dtype=dtype, shape=(n, n))
+
+    def _matmat(self, other_matrix, *, skip_op_idx: Optional[int] = None):
+        n, k = self.shape[0], other_matrix.shape[1]
+        with _nvtx("MultiStdXXTOp_matmat"):
+            active = [
+                (i, op) for i, op in enumerate(self.operators)
+                if skip_op_idx is None or i != skip_op_idx
+            ]
+            if not active:
+                with cuda.Device(self._output_device):
+                    return xp.zeros((n, k), dtype=self.dtype)
+            parts = []
+            for _ in active:
+                with cuda.Device(self._output_device):
+                    parts.append(xp.empty((n, k), dtype=self.dtype))
+            self.scheduler.reset()
+            futures = []
+            for (_, op), part in zip(active, parts):
+                futures.append(
+                    self.scheduler.submit(
+                        op.grg, CuPyStdXXTOperator._matmat, op, other_matrix, part
+                    )
+                )
+            self.scheduler.start()
+            for f in futures:
+                f.result()
+            with cuda.Device(self._output_device):
+                cuda.Device(self._output_device).synchronize()
+                result = sum(parts[1:], parts[0])
+                xp.cuda.get_current_stream().synchronize()
+            return result
+
+    def _rmatmat(self, other_matrix):
+        return self._matmat(other_matrix)
+
+    def _matvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._matmat(vect)
+
+    def _rmatvec(self, vect):
+        if vect.ndim != 2:
+            with cuda.Device(self._output_device):
+                vect = _xdev_asarray(vect).reshape(-1, 1)
+        return self._rmatmat(vect)
+
+    def matvec_loco(self, v, *, exclude_op_idx: Optional[int] = None):
+        """Compute sum_{i != exclude_op_idx} X_i X_i^T @ v in parallel on GPU."""
+        was_vec = (v.ndim == 1)
+        if was_vec:
+            with cuda.Device(self._output_device):
+                v_col = xp.asarray(v).reshape(-1, 1)
+        else:
+            v_col = v
+        result = self._matmat(v_col, skip_op_idx=exclude_op_idx)
+        return result[:, 0] if was_vec else result

--- a/grapp/linalg/ops_cupy.py
+++ b/grapp/linalg/ops_cupy.py
@@ -7,9 +7,9 @@ not installed.
 
 Memory model
 ------------
-For single-GRG operators, the input and output buffers are assumed to be 
-on the GRG's device. For multi-GRG operators, the input and output buffers 
-are assumed to be on the "primary device", which should be the device of 
+For single-GRG operators, the input and output buffers are assumed to be
+on the GRG's device. For multi-GRG operators, the input and output buffers
+are assumed to be on the "primary device", which should be the device of
 the first GRG.
 
 Stream model
@@ -31,7 +31,6 @@ from grapp.grg_calculator import (
     _wrap_grg,
 )
 
-
 # When True, cross-device copies are routed D2H + H2D instead of using
 # cudaMemcpyPeer / NVLink.  Set before any operator _matmat call to benchmark
 # PCIe-only transfers.
@@ -44,12 +43,15 @@ _UP = TraversalDirection.UP
 def _flip_dir(direction: TraversalDirection) -> TraversalDirection:
     return _UP if direction == _DOWN else _DOWN
 
+
 def _transpose_shape(shape: Tuple[int, int]) -> Tuple[int, int]:
     return (shape[1], shape[0])
+
 
 # ---------------------------------------------------------------------------
 # NVTX helper
 # ---------------------------------------------------------------------------
+
 
 @contextmanager
 def _nvtx(name: str):
@@ -65,6 +67,7 @@ def _nvtx(name: str):
 # Cross-device helpers
 # ---------------------------------------------------------------------------
 
+
 def _xdev_copy(dst, src) -> None:
     """Write src into dst, routing through host when force_host_xdev_copy is set.
 
@@ -76,7 +79,11 @@ def _xdev_copy(dst, src) -> None:
         with cuda.Device(dst.device):
             dst[:] = xp.asarray(src.get())
     else:
-        if hasattr(src, "device") and hasattr(dst, "device") and src.device != dst.device:
+        if (
+            hasattr(src, "device")
+            and hasattr(dst, "device")
+            and src.device != dst.device
+        ):
             with cuda.Device(src.device):
                 xp.cuda.get_current_stream().synchronize()
         with cuda.Device(dst.device):
@@ -85,8 +92,7 @@ def _xdev_copy(dst, src) -> None:
 
 
 def _xdev_asarray(src):
-    """Return src as a CuPy array on the current device, copying if necessary.
-    """
+    """Return src as a CuPy array on the current device, copying if necessary."""
     if force_host_xdev_copy and hasattr(src, "get"):
         return xp.asarray(src.get())
     dev = getattr(src, "device", None)
@@ -102,6 +108,7 @@ def _xdev_asarray(src):
 # ---------------------------------------------------------------------------
 # GRGOpFilter
 # ---------------------------------------------------------------------------
+
 
 class GRGOpFilter:
     """Handles optional mutation and sample sub-selection for GRG operators."""
@@ -135,7 +142,9 @@ class GRGOpFilter:
             self.grg_shape[0] if sample_filter is None else len(sample_filter),
             self.grg_shape[1] if mutation_filter is None else len(mutation_filter),
         )
-        self.is_filtering = self.sample_filter is not None or self.mutation_filter is not None
+        self.is_filtering = (
+            self.sample_filter is not None or self.mutation_filter is not None
+        )
         self._device = getattr(grg, "device", None)
 
     def prep_input(self, input_matrix, mult_dir: TraversalDirection):
@@ -219,7 +228,9 @@ class CuPyXOperator(LinearOperator):
             miss_values is None or miss_values.ndim == 1
         ), '"miss_values" must be a 1-D vector'
         with cuda.Device(self._device):
-            self.miss_values = xp.asarray(miss_values) if miss_values is not None else None
+            self.miss_values = (
+                xp.asarray(miss_values) if miss_values is not None else None
+            )
         shape = self.filter.shape
         if self.direction == _DOWN:
             shape = _transpose_shape(shape)
@@ -291,8 +302,13 @@ class CuPyXTXOperator(LinearOperator):
         sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
     ):
         self.x_op = CuPyXOperator(
-            grg, _UP, dtype=dtype, haploid=haploid, miss_values=miss_values,
-            mutation_filter=mutation_filter, sample_filter=sample_filter,
+            grg,
+            _UP,
+            dtype=dtype,
+            haploid=haploid,
+            miss_values=miss_values,
+            mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
         )
         self._device = self.x_op._device
         super().__init__(dtype=dtype, shape=(self.x_op.shape[1], self.x_op.shape[1]))
@@ -331,8 +347,13 @@ class CuPyXXTOperator(LinearOperator):
         sample_filter: Optional[Union[List[int], numpy.ndarray]] = None,
     ):
         self.x_op = CuPyXOperator(
-            grg, _UP, dtype=dtype, haploid=haploid, miss_values=miss_values,
-            mutation_filter=mutation_filter, sample_filter=sample_filter,
+            grg,
+            _UP,
+            dtype=dtype,
+            haploid=haploid,
+            miss_values=miss_values,
+            mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
         )
         self._device = self.x_op._device
         self.grg = self.x_op.grg
@@ -366,6 +387,7 @@ class CuPyXXTOperator(LinearOperator):
 # ---------------------------------------------------------------------------
 # Standardized operators
 # ---------------------------------------------------------------------------
+
 
 class _CuPyStandardizedOperator(LinearOperator):
     """
@@ -447,14 +469,21 @@ class CuPyStdXOperator(_CuPyStandardizedOperator):
         alpha: float = -1,
         custom_variance: Optional[numpy.ndarray] = None,
     ):
-        self.filter = GRGOpFilter(_wrap_grg(grg), haploid, mutation_filter, sample_filter)
+        self.filter = GRGOpFilter(
+            _wrap_grg(grg), haploid, mutation_filter, sample_filter
+        )
         self.direction = direction
         shape = self.filter.shape
         if self.direction == _DOWN:
             shape = _transpose_shape(shape)
         super().__init__(
-            grg, freqs, shape, dtype=dtype, haploid=haploid,
-            alpha=alpha, custom_variance=custom_variance,
+            grg,
+            freqs,
+            shape,
+            dtype=dtype,
+            haploid=haploid,
+            alpha=alpha,
+            custom_variance=custom_variance,
         )
 
     def _matmat_direction(self, other_matrix, direction: TraversalDirection, out=None):
@@ -508,7 +537,9 @@ class CuPyStdXOperator(_CuPyStandardizedOperator):
                             sub_const2 = (
                                 self.mult_const * self.freqs * self.inverse_sigma
                             ) * col_const
-                            result = self.filter.adjust_output(SXv - sub_const2, mult_dir).T
+                            result = self.filter.adjust_output(
+                                SXv - sub_const2, mult_dir
+                            ).T
 
                 if out is not None:
                     # Sync self._device stream; queue copy on out.device's null stream.
@@ -550,9 +581,15 @@ class CuPyStdXTXOperator(LinearOperator):
         custom_variance: Optional[numpy.ndarray] = None,
     ):
         self.std_x_op = CuPyStdXOperator(
-            grg, _UP, freqs, dtype=dtype, haploid=haploid,
-            mutation_filter=mutation_filter, sample_filter=sample_filter,
-            alpha=alpha, custom_variance=custom_variance,
+            grg,
+            _UP,
+            freqs,
+            dtype=dtype,
+            haploid=haploid,
+            mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
+            alpha=alpha,
+            custom_variance=custom_variance,
         )
         self._device = self.std_x_op._device
         super().__init__(
@@ -595,9 +632,15 @@ class CuPyStdXXTOperator(LinearOperator):
         custom_variance: Optional[numpy.ndarray] = None,
     ):
         self.std_x_op = CuPyStdXOperator(
-            grg, _UP, freqs, dtype=dtype, haploid=haploid,
-            mutation_filter=mutation_filter, sample_filter=sample_filter,
-            alpha=alpha, custom_variance=custom_variance,
+            grg,
+            _UP,
+            freqs,
+            dtype=dtype,
+            haploid=haploid,
+            mutation_filter=mutation_filter,
+            sample_filter=sample_filter,
+            alpha=alpha,
+            custom_variance=custom_variance,
         )
         self._device = self.std_x_op._device
         self.grg = self.std_x_op.grg
@@ -633,6 +676,7 @@ class CuPyStdXXTOperator(LinearOperator):
 # ---------------------------------------------------------------------------
 # Multi-GRG operators
 # ---------------------------------------------------------------------------
+
 
 def _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g):
     """Remap global mutation_filter indices to per-GRG local indices."""
@@ -682,18 +726,29 @@ class MultiCuPyXOperator(LinearOperator):
         prev_miss_start = 0
         prev_max_mut = 0
         for g in grgs:
-            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
-            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
+            assert (
+                g.num_samples == grgs[0].num_samples
+            ), "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(
+                mutation_filter, prev_max_mut, g
+            )
             if not skip:
-                effective_muts = len(grg_mut_filt) if grg_mut_filt is not None else g.num_mutations
+                effective_muts = (
+                    len(grg_mut_filt) if grg_mut_filt is not None else g.num_mutations
+                )
                 if miss_values is not None:
-                    grg_miss = miss_values[prev_miss_start:prev_miss_start + effective_muts]
+                    grg_miss = miss_values[
+                        prev_miss_start : prev_miss_start + effective_muts
+                    ]
                     prev_miss_start += effective_muts
                 else:
                     grg_miss = None
                 self.operators.append(
                     CuPyXOperator(
-                        g, direction, dtype, haploid=haploid,
+                        g,
+                        direction,
+                        dtype,
+                        haploid=haploid,
                         miss_values=grg_miss,
                         mutation_filter=grg_mut_filt,
                         sample_filter=sample_filter,
@@ -703,9 +758,15 @@ class MultiCuPyXOperator(LinearOperator):
         self._output_device = self.operators[0]._device
         self.scheduler = _wrap_grg(grgs[0]).make_scheduler(grgs, threads)
         if direction == _UP:
-            shape = (self.operators[0].shape[0], sum(op.shape[1] for op in self.operators))
+            shape = (
+                self.operators[0].shape[0],
+                sum(op.shape[1] for op in self.operators),
+            )
         else:
-            shape = (sum(op.shape[0] for op in self.operators), self.operators[0].shape[1])
+            shape = (
+                sum(op.shape[0] for op in self.operators),
+                self.operators[0].shape[1],
+            )
         super().__init__(dtype=dtype, shape=shape)
 
     def _matmat_helper(self, other_matrix, direction, op_method):
@@ -719,11 +780,13 @@ class MultiCuPyXOperator(LinearOperator):
                 # axes of each sub-operator depend on self.direction (UP exposes
                 # shape (N, M_i); DOWN exposes shape (M_i, N)).
                 op_muts = (
-                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    (lambda op: op.shape[0])
+                    if self.direction == _DOWN
                     else (lambda op: op.shape[1])
                 )
                 n_rows = (
-                    self.operators[0].shape[1] if self.direction == _DOWN
+                    self.operators[0].shape[1]
+                    if self.direction == _DOWN
                     else self.operators[0].shape[0]
                 )
                 parts = []
@@ -736,7 +799,9 @@ class MultiCuPyXOperator(LinearOperator):
                     sub = other_matrix[start:end, :]
                     with cuda.Device(op._device):
                         sub = _xdev_asarray(sub)
-                    futures.append(self.scheduler.submit(op.grg, op_method, op, sub, part))
+                    futures.append(
+                        self.scheduler.submit(op.grg, op_method, op, sub, part)
+                    )
                     start = end
                 returned_parts = []
                 for f in futures:
@@ -750,7 +815,8 @@ class MultiCuPyXOperator(LinearOperator):
             else:
                 # Each op gets the full input; outputs are concatenated.
                 op_rows = (
-                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    (lambda op: op.shape[0])
+                    if self.direction == _DOWN
                     else (lambda op: op.shape[1])
                 )
                 total_rows = sum(op_rows(op) for op in self.operators)
@@ -763,7 +829,9 @@ class MultiCuPyXOperator(LinearOperator):
                     with cuda.Device(op._device):
                         op_input = _xdev_asarray(other_matrix)
                     futures.append(
-                        self.scheduler.submit(op.grg, op_method, op, op_input, out_slice)
+                        self.scheduler.submit(
+                            op.grg, op_method, op, op_input, out_slice
+                        )
                     )
                     start = end
                 for f in futures:
@@ -812,7 +880,10 @@ class MultiCuPyXTXOperator(LinearOperator):
         threads: int = 1,
     ):
         self.x_op = MultiCuPyXOperator(
-            grgs, _UP, dtype=dtype, haploid=haploid,
+            grgs,
+            _UP,
+            dtype=dtype,
+            haploid=haploid,
             miss_values=miss_values,
             mutation_filter=mutation_filter,
             sample_filter=sample_filter,
@@ -867,18 +938,28 @@ class MultiCuPyXXTOperator(LinearOperator):
         prev_miss_start = 0
         prev_max_mut = 0
         for g in grgs:
-            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
-            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
+            assert (
+                g.num_samples == grgs[0].num_samples
+            ), "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(
+                mutation_filter, prev_max_mut, g
+            )
             if not skip:
-                effective_muts = len(grg_mut_filt) if grg_mut_filt is not None else g.num_mutations
+                effective_muts = (
+                    len(grg_mut_filt) if grg_mut_filt is not None else g.num_mutations
+                )
                 if miss_values is not None:
-                    grg_miss = miss_values[prev_miss_start:prev_miss_start + effective_muts]
+                    grg_miss = miss_values[
+                        prev_miss_start : prev_miss_start + effective_muts
+                    ]
                     prev_miss_start += effective_muts
                 else:
                     grg_miss = None
                 self.operators.append(
                     CuPyXXTOperator(
-                        g, dtype, haploid=haploid,
+                        g,
+                        dtype,
+                        haploid=haploid,
                         miss_values=grg_miss,
                         mutation_filter=grg_mut_filt,
                         sample_filter=sample_filter,
@@ -957,18 +1038,32 @@ class MultiCuPyStdXOperator(LinearOperator):
         assert len(grgs) >= 1, "Must provide at least one GRG"
         assert len(grgs) == len(freqs), "Must provide allele frequencies for every GRG"
         if isinstance(custom_variance, list):
-            assert len(custom_variance) == len(grgs), "custom_variance list must have one entry per GRG"
+            assert len(custom_variance) == len(
+                grgs
+            ), "custom_variance list must have one entry per GRG"
         self.direction = direction
         self.operators: List[CuPyStdXOperator] = []
         prev_max_mut = 0
         for i, (g, f) in enumerate(zip(grgs, freqs)):
-            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
-            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
-            grg_custom_var = custom_variance[i] if isinstance(custom_variance, list) else custom_variance
+            assert (
+                g.num_samples == grgs[0].num_samples
+            ), "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(
+                mutation_filter, prev_max_mut, g
+            )
+            grg_custom_var = (
+                custom_variance[i]
+                if isinstance(custom_variance, list)
+                else custom_variance
+            )
             if not skip:
                 self.operators.append(
                     CuPyStdXOperator(
-                        g, direction, f, dtype, haploid=haploid,
+                        g,
+                        direction,
+                        f,
+                        dtype,
+                        haploid=haploid,
                         mutation_filter=grg_mut_filt,
                         sample_filter=sample_filter,
                         alpha=alpha,
@@ -979,9 +1074,15 @@ class MultiCuPyStdXOperator(LinearOperator):
         self._output_device = self.operators[0]._device
         self.scheduler = _wrap_grg(grgs[0]).make_scheduler(grgs, threads)
         if direction == _UP:
-            shape = (self.operators[0].shape[0], sum(op.shape[1] for op in self.operators))
+            shape = (
+                self.operators[0].shape[0],
+                sum(op.shape[1] for op in self.operators),
+            )
         else:
-            shape = (sum(op.shape[0] for op in self.operators), self.operators[0].shape[1])
+            shape = (
+                sum(op.shape[0] for op in self.operators),
+                self.operators[0].shape[1],
+            )
         super().__init__(dtype=dtype, shape=shape)
 
     def _matmat_helper(self, other_matrix, direction, op_method):
@@ -995,11 +1096,13 @@ class MultiCuPyStdXOperator(LinearOperator):
                 # axes of each sub-operator depend on self.direction (UP exposes
                 # shape (N, M_i); DOWN exposes shape (M_i, N)).
                 op_muts = (
-                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    (lambda op: op.shape[0])
+                    if self.direction == _DOWN
                     else (lambda op: op.shape[1])
                 )
                 n_rows = (
-                    self.operators[0].shape[1] if self.direction == _DOWN
+                    self.operators[0].shape[1]
+                    if self.direction == _DOWN
                     else self.operators[0].shape[0]
                 )
                 parts = []
@@ -1012,7 +1115,9 @@ class MultiCuPyStdXOperator(LinearOperator):
                     sub = other_matrix[start:end, :]
                     with cuda.Device(op._device):
                         sub = _xdev_asarray(sub)
-                    futures.append(self.scheduler.submit(op.grg, op_method, op, sub, part))
+                    futures.append(
+                        self.scheduler.submit(op.grg, op_method, op, sub, part)
+                    )
                     start = end
                 for f in futures:
                     f.result()
@@ -1022,7 +1127,8 @@ class MultiCuPyStdXOperator(LinearOperator):
                 return result
             else:
                 op_rows = (
-                    (lambda op: op.shape[0]) if self.direction == _DOWN
+                    (lambda op: op.shape[0])
+                    if self.direction == _DOWN
                     else (lambda op: op.shape[1])
                 )
                 total_rows = sum(op_rows(op) for op in self.operators)
@@ -1035,7 +1141,9 @@ class MultiCuPyStdXOperator(LinearOperator):
                     with cuda.Device(op._device):
                         op_input = _xdev_asarray(other_matrix)
                     futures.append(
-                        self.scheduler.submit(op.grg, op_method, op, op_input, out_slice)
+                        self.scheduler.submit(
+                            op.grg, op_method, op, op_input, out_slice
+                        )
                     )
                     start = end
                 for f in futures:
@@ -1045,7 +1153,9 @@ class MultiCuPyStdXOperator(LinearOperator):
                 return output
 
     def _matmat(self, other_matrix):
-        return self._matmat_helper(other_matrix, self.direction, CuPyStdXOperator._matmat)
+        return self._matmat_helper(
+            other_matrix, self.direction, CuPyStdXOperator._matmat
+        )
 
     def _rmatmat(self, other_matrix):
         return self._matmat_helper(
@@ -1083,7 +1193,11 @@ class MultiCuPyStdXTXOperator(LinearOperator):
         custom_variance: Optional[numpy.ndarray] = None,
     ):
         self.std_x_op = MultiCuPyStdXOperator(
-            grgs, _UP, freqs, dtype=dtype, haploid=haploid,
+            grgs,
+            _UP,
+            freqs,
+            dtype=dtype,
+            haploid=haploid,
             mutation_filter=mutation_filter,
             sample_filter=sample_filter,
             threads=threads,
@@ -1143,17 +1257,30 @@ class MultiCuPyStdXXTOperator(LinearOperator):
         assert len(grgs) >= 1, "Must provide at least one GRG"
         assert len(grgs) == len(freqs), "Must provide allele frequencies for every GRG"
         if isinstance(custom_variance, list):
-            assert len(custom_variance) == len(grgs), "custom_variance list must have one entry per GRG"
+            assert len(custom_variance) == len(
+                grgs
+            ), "custom_variance list must have one entry per GRG"
         self.operators: List[CuPyStdXXTOperator] = []
         prev_max_mut = 0
         for i, (g, f) in enumerate(zip(grgs, freqs)):
-            assert g.num_samples == grgs[0].num_samples, "All GRGs must use the same samples"
-            grg_mut_filt, skip = _build_per_grg_mut_filt(mutation_filter, prev_max_mut, g)
-            grg_custom_var = custom_variance[i] if isinstance(custom_variance, list) else custom_variance
+            assert (
+                g.num_samples == grgs[0].num_samples
+            ), "All GRGs must use the same samples"
+            grg_mut_filt, skip = _build_per_grg_mut_filt(
+                mutation_filter, prev_max_mut, g
+            )
+            grg_custom_var = (
+                custom_variance[i]
+                if isinstance(custom_variance, list)
+                else custom_variance
+            )
             if not skip:
                 self.operators.append(
                     CuPyStdXXTOperator(
-                        g, f, dtype, haploid=haploid,
+                        g,
+                        f,
+                        dtype,
+                        haploid=haploid,
                         mutation_filter=grg_mut_filt,
                         sample_filter=sample_filter,
                         alpha=alpha,
@@ -1170,7 +1297,8 @@ class MultiCuPyStdXXTOperator(LinearOperator):
         n, k = self.shape[0], other_matrix.shape[1]
         with _nvtx("MultiStdXXTOp_matmat"):
             active = [
-                (i, op) for i, op in enumerate(self.operators)
+                (i, op)
+                for i, op in enumerate(self.operators)
                 if skip_op_idx is None or i != skip_op_idx
             ]
             if not active:
@@ -1214,7 +1342,7 @@ class MultiCuPyStdXXTOperator(LinearOperator):
 
     def matvec_loco(self, v, *, exclude_op_idx: Optional[int] = None):
         """Compute sum_{i != exclude_op_idx} X_i X_i^T @ v in parallel on GPU."""
-        was_vec = (v.ndim == 1)
+        was_vec = v.ndim == 1
         if was_vec:
             with cuda.Device(self._output_device):
                 v_col = xp.asarray(v).reshape(-1, 1)

--- a/grapp/util/simple.py
+++ b/grapp/util/simple.py
@@ -154,6 +154,91 @@ def allele_frequencies(
             out=numpy.zeros(acounts.shape, dtype=numpy.float64),
             where=(denominator != 0),
         )
+    
+def allele_counts_cupy(
+    grg: Union[pygrgl.GRG, _GRGCalcInterface],
+    return_missing: bool = False,
+    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
+) -> Union["cupy.ndarray", Tuple["cupy.ndarray", "cupy.ndarray"]]:
+    """
+    CuPy variant of allele_counts. Input and output arrays are cupy arrays on
+    the device owned by the GRG. The GRG must support GPU-resident matmul
+    (e.g. NativeCapturedBoundGRG).
+    """
+    import cupy
+    grg = _wrap_grg(grg)
+    if isinstance(sample_filter, numpy.ndarray):
+        sample_filter = sample_filter.tolist()
+    if sample_filter is not None:
+        assert len(set(sample_filter)) == len(
+            sample_filter
+        ), "Duplicate IDs in sample_filter"
+        assert len(sample_filter) <= grg.num_samples
+    kwargs = {}
+    with cupy.cuda.Device(grg.device):
+        if return_missing:
+            miss_counts = cupy.zeros((1, grg.num_mutations), dtype=cupy.int32)
+            kwargs["miss"] = miss_counts
+        else:
+            miss_counts = None
+        if sample_filter is not None:
+            input_mat = cupy.zeros((1, grg.num_samples), dtype=cupy.int32)
+            input_mat[:, sample_filter] = 1
+        else:
+            input_mat = cupy.ones((1, grg.num_samples), dtype=cupy.int32)
+        acounts = grg.matmul(input_mat, pygrgl.TraversalDirection.UP, **kwargs)[0]  # type: ignore
+        # Sync the GRG device's stream after the native matmul so the counts are fully
+        # materialized before any downstream CuPy reads (matches grapp/linalg/ops_cupy.py).
+        cupy.cuda.get_current_stream().synchronize()
+    if miss_counts is not None:
+        miss_counts = miss_counts[0]
+        assert miss_counts is not None
+        return acounts, miss_counts
+    return acounts
+
+
+def allele_frequencies_cupy(
+    grg: Union[pygrgl.GRG, _GRGCalcInterface],
+    adjust_missing: bool = False,
+    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None
+) -> numpy.typing.NDArray:
+    """
+    Get the allele frequencies for the mutations in the given GRG.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :param adjust_missing: Optional. Set to true to adjust each allele frequncies to be
+        :math:`\\frac{count_i}{total - missing_i}` instead of :math:`\\frac{count_i}{total}`.
+    :type adjust_missing: bool
+    :param sample_filter: Only consider the samples listed in the filter. Default: no filter.
+    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
+    :return: A vector of length grg.num_mutations, containing allele frequencies
+        indexed by MutationID.
+    :rtype: numpy.ndarray
+    """
+    grg = _wrap_grg(grg)
+    import cupy
+    num_samples = grg.num_samples if sample_filter is None else len(sample_filter)
+    with cupy.cuda.Device(grg.device):
+        if adjust_missing:
+            acounts, miss_counts = allele_counts_cupy(
+                grg, return_missing=True, sample_filter=sample_filter
+            )
+            denominator = num_samples - miss_counts  # cupy array
+            assert cupy.all(denominator >= 0)
+            safe = cupy.where(denominator > 0, denominator, 1).astype(cupy.float64)
+            result = acounts.astype(cupy.float64) / safe
+            result[denominator == 0] = 0.0
+            cupy.cuda.get_current_stream().synchronize()
+            return result
+        else:
+            acounts = allele_counts_cupy(
+                grg, return_missing=False, sample_filter=sample_filter
+            )
+            result = acounts.astype(cupy.float64) / num_samples
+            cupy.cuda.get_current_stream().synchronize()
+            return result
+
 
 
 def variance(

--- a/grapp/util/simple.py
+++ b/grapp/util/simple.py
@@ -97,17 +97,18 @@ def allele_counts(
         ), "Duplicate IDs in sample_filter"
         assert len(sample_filter) <= grg.num_samples
     kwargs = {}
-    if return_missing:
-        miss_counts = numpy.zeros((1, grg.num_mutations), dtype=numpy.int32)
-        kwargs["miss"] = miss_counts
-    else:
-        miss_counts = None
-    if sample_filter is not None:
-        input_mat = numpy.zeros((1, grg.num_samples), dtype=numpy.int32)
-        input_mat[:, sample_filter] = 1
-    else:
-        input_mat = numpy.ones((1, grg.num_samples), dtype=numpy.int32)
-    acounts = grg.matmul(input_mat, pygrgl.TraversalDirection.UP, **kwargs)[0]  # type: ignore
+    with grg.device_context():
+        if return_missing:
+            miss_counts = numpy.zeros((1, grg.num_mutations), dtype=numpy.int32)
+            kwargs["miss"] = miss_counts
+        else:
+            miss_counts = None
+        if sample_filter is not None:
+            input_mat = numpy.zeros((1, grg.num_samples), dtype=numpy.int32)
+            input_mat[:, sample_filter] = 1
+        else:
+            input_mat = numpy.ones((1, grg.num_samples), dtype=numpy.int32)
+        acounts = grg.matmul(input_mat, pygrgl.TraversalDirection.UP, **kwargs)[0]  # type: ignore
     if miss_counts is not None:
         miss_counts = miss_counts[0]
         assert miss_counts is not None
@@ -135,7 +136,7 @@ def allele_frequencies(
     :rtype: numpy.ndarray
     """
     grg = _wrap_grg(grg)
-    with numpy.errstate(divide="raise"):
+    with grg.device_context():
         if adjust_missing:
             acounts, miss_counts = allele_counts(
                 grg, return_missing=True, sample_filter=sample_filter
@@ -154,91 +155,6 @@ def allele_frequencies(
             out=numpy.zeros(acounts.shape, dtype=numpy.float64),
             where=(denominator != 0),
         )
-    
-def allele_counts_cupy(
-    grg: Union[pygrgl.GRG, _GRGCalcInterface],
-    return_missing: bool = False,
-    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None,
-) -> Union["cupy.ndarray", Tuple["cupy.ndarray", "cupy.ndarray"]]:
-    """
-    CuPy variant of allele_counts. Input and output arrays are cupy arrays on
-    the device owned by the GRG. The GRG must support GPU-resident matmul
-    (e.g. NativeCapturedBoundGRG).
-    """
-    import cupy
-    grg = _wrap_grg(grg)
-    if isinstance(sample_filter, numpy.ndarray):
-        sample_filter = sample_filter.tolist()
-    if sample_filter is not None:
-        assert len(set(sample_filter)) == len(
-            sample_filter
-        ), "Duplicate IDs in sample_filter"
-        assert len(sample_filter) <= grg.num_samples
-    kwargs = {}
-    with cupy.cuda.Device(grg.device):
-        if return_missing:
-            miss_counts = cupy.zeros((1, grg.num_mutations), dtype=cupy.int32)
-            kwargs["miss"] = miss_counts
-        else:
-            miss_counts = None
-        if sample_filter is not None:
-            input_mat = cupy.zeros((1, grg.num_samples), dtype=cupy.int32)
-            input_mat[:, sample_filter] = 1
-        else:
-            input_mat = cupy.ones((1, grg.num_samples), dtype=cupy.int32)
-        acounts = grg.matmul(input_mat, pygrgl.TraversalDirection.UP, **kwargs)[0]  # type: ignore
-        # Sync the GRG device's stream after the native matmul so the counts are fully
-        # materialized before any downstream CuPy reads (matches grapp/linalg/ops_cupy.py).
-        cupy.cuda.get_current_stream().synchronize()
-    if miss_counts is not None:
-        miss_counts = miss_counts[0]
-        assert miss_counts is not None
-        return acounts, miss_counts
-    return acounts
-
-
-def allele_frequencies_cupy(
-    grg: Union[pygrgl.GRG, _GRGCalcInterface],
-    adjust_missing: bool = False,
-    sample_filter: Optional[Union[List[int], numpy.typing.NDArray]] = None
-) -> numpy.typing.NDArray:
-    """
-    Get the allele frequencies for the mutations in the given GRG.
-
-    :param grg: The GRG.
-    :type grg: pygrgl.GRG
-    :param adjust_missing: Optional. Set to true to adjust each allele frequncies to be
-        :math:`\\frac{count_i}{total - missing_i}` instead of :math:`\\frac{count_i}{total}`.
-    :type adjust_missing: bool
-    :param sample_filter: Only consider the samples listed in the filter. Default: no filter.
-    :type sample_filter: Optional[Union[List[int], numpy.typing.NDArray]]
-    :return: A vector of length grg.num_mutations, containing allele frequencies
-        indexed by MutationID.
-    :rtype: numpy.ndarray
-    """
-    grg = _wrap_grg(grg)
-    import cupy
-    num_samples = grg.num_samples if sample_filter is None else len(sample_filter)
-    with cupy.cuda.Device(grg.device):
-        if adjust_missing:
-            acounts, miss_counts = allele_counts_cupy(
-                grg, return_missing=True, sample_filter=sample_filter
-            )
-            denominator = num_samples - miss_counts  # cupy array
-            assert cupy.all(denominator >= 0)
-            safe = cupy.where(denominator > 0, denominator, 1).astype(cupy.float64)
-            result = acounts.astype(cupy.float64) / safe
-            result[denominator == 0] = 0.0
-            cupy.cuda.get_current_stream().synchronize()
-            return result
-        else:
-            acounts = allele_counts_cupy(
-                grg, return_missing=False, sample_filter=sample_filter
-            )
-            result = acounts.astype(cupy.float64) / num_samples
-            cupy.cuda.get_current_stream().synchronize()
-            return result
-
 
 
 def variance(
@@ -266,30 +182,31 @@ def variance(
     :rtype: numpy.ndarray
     """
     grg = _wrap_grg(grg)
-    mult_const = 1 if haploid else grg.ploidy
-    acount, miss_count = allele_counts(
-        grg, return_missing=True, sample_filter=sample_filter
-    )
-    n_j = (
-        (grg.num_samples - miss_count)
-        if adjust_missing
-        else numpy.full(grg.num_mutations, grg.num_samples)
-    )
-    afreq = _div_or_default(acount, n_j, 0.0)
-    if dist == _GenotypeDist.SAMPLE.value:
-        assert (
-            not haploid and grg.ploidy == 2
-        ), "The sample-based variance can only be computed for diploids"
-        # diag(X^T @ X) / n = Var[X] + E[X]^2
-        # --> Var[X] = (diag(X^T @ X) / n) - E[X]^2
-        XX = grg.matmul(
-            numpy.ones((1, grg.num_samples), dtype=numpy.int32),
-            pygrgl.TraversalDirection.UP,
-            init="xtx",
-        )[0]
-        return (XX / grg.num_individuals) - ((mult_const * afreq) ** 2)
-    else:
-        return mult_const * afreq * (1.0 - afreq)
+    with grg.device_context():
+        mult_const = 1 if haploid else grg.ploidy
+        acount, miss_count = allele_counts(
+            grg, return_missing=True, sample_filter=sample_filter
+        )
+        n_j = (
+            (grg.num_samples - miss_count)
+            if adjust_missing
+            else numpy.full(grg.num_mutations, grg.num_samples)
+        )
+        afreq = _div_or_default(acount, n_j, 0.0)
+        if dist == _GenotypeDist.SAMPLE.value:
+            assert (
+                not haploid and grg.ploidy == 2
+            ), "The sample-based variance can only be computed for diploids"
+            # diag(X^T @ X) / n = Var[X] + E[X]^2
+            # --> Var[X] = (diag(X^T @ X) / n) - E[X]^2
+            XX = grg.matmul(
+                numpy.ones((1, grg.num_samples), dtype=numpy.int32),
+                pygrgl.TraversalDirection.UP,
+                init="xtx",
+            )[0]
+            return (XX / grg.num_individuals) - ((mult_const * afreq) ** 2)
+        else:
+            return mult_const * afreq * (1.0 - afreq)
 
 
 def _star_snphwe_pygrgl(arglist):


### PR DESCRIPTION
This PR supports cupy-native operators, which eliminate redundant device-host memory copies when doing calculations on GPUs. Major changes include:
- Gated Scheduler for GRGSpMV calculators, which would pause all threads until a manual start;
- Cupy Version of the Linear Operators and `allele_frequencies`;
- Support of `getOperator` interface for GRGCalculators;
- Adaption of the `get_eig_pcs` function to use the `getOperator` interface.

When cupy is not installed, grapp is expected to perform as before.

A few more changes have been made to PCA. The `init_vector` is supported as optional input vector to ensure reproducibility. `tol` is supported as optional input param as cupy and scipy has different default tolerance. `include_eig_val` would return the eigen value when using XXT operator.