### PR TITLE
Add polarization for FASTA-based mutation polarization

### DIFF
--- a/grapp/cli/main.py
+++ b/grapp/cli/main.py
@@ -4,6 +4,7 @@ from grapp.cli import filter_cli
 from grapp.cli import pca_cli
 from grapp.cli import show_cli
 from grapp.cli import pheno_cli
+from grapp.cli import polar_cli
 from grapp.util.exceptions import UserInputError
 
 import argparse
@@ -15,6 +16,7 @@ CMD_EXPORT = "export"
 CMD_FILTER = "filter"
 CMD_SHOW = "show"
 CMD_PHENO = "pheno"
+CMD_POLARIZE = "polarize"
 
 
 def main():
@@ -50,6 +52,11 @@ def main():
         help="Simulate phenotypes with a GRG.",
     )
     pheno_cli.add_options(pheno_parser)
+    polar_parser = subparsers.add_parser(
+        CMD_POLARIZE,
+        help="Polarize a GRG using an ancestral sequence.",
+    )
+    polar_cli.add_options(polar_parser)
 
     try:
         args = parser.parse_args()
@@ -69,6 +76,8 @@ def main():
             show_cli.run(args)
         elif args.command == CMD_PHENO:
             pheno_cli.run(args)
+        elif args.command == CMD_POLARIZE:
+            polar_cli.run(args)
         else:
             print(f"Invalid command {args.command}", file=sys.stderr)
             parser.print_help()

--- a/grapp/cli/polar_cli.py
+++ b/grapp/cli/polar_cli.py
@@ -1,0 +1,105 @@
+from grapp.popgen.polarize import (
+    polarize_grg,
+    PolarizationStats,
+    DEFAULT_BATCH_SIZE,
+)
+from typing import Tuple, Any
+import argparse
+import os
+import pyfaidx
+import pygrgl
+import sys
+
+
+def load_fasta(path: str) -> Tuple[Any, str]:
+    fasta = pyfaidx.Fasta(path, as_raw=False, sequence_always_upper=True)
+    contigs = list(fasta.keys())
+    if len(contigs) != 1:
+        raise ValueError(
+            "FASTA must contain exactly one contig for grg polarize. "
+            f"Found: {', '.join(contigs)}"
+        )
+    return fasta, contigs[0]
+
+
+def polarize_grg_from_fasta(
+    grg: pygrgl.MutableGRG,
+    fasta_file: str,
+    drop_if_no_match: bool = True,
+    map_batch_size: int = DEFAULT_BATCH_SIZE,
+) -> PolarizationStats:
+    fasta, contig = load_fasta(fasta_file)
+    ancestral_sequence = str(
+        fasta[contig][:]
+    ).upper()  # TODO: shouldn't this always be upper, because you passed sequence_always_upper=True?
+    return polarize_grg(grg, ancestral_sequence, drop_if_no_match, map_batch_size)
+
+
+def add_options(subparser):
+    subparser.add_argument("grg_input", help="Input GRG file to polarize")
+    subparser.add_argument(
+        "fasta_file", help="FASTA containing (only) the ancestral sequence"
+    )
+    subparser.add_argument(
+        "-o",
+        "--output",
+        dest="output_file",
+        required=True,
+        help="Output GRG file",
+    )
+    subparser.add_argument(
+        "--keep-no-match",
+        action="store_true",
+        help="Keep mutations with no matching allele in the FASTA (instead of dropping them)",
+    )
+    subparser.add_argument(
+        "--map-batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="Number of flipped mutations to process per graph traversal; larger values use more RAM",
+    )
+
+
+def run(args):
+    if not os.path.isfile(args.grg_input):
+        print(f"Input GRG file does not exist: {args.grg_input}", file=sys.stderr)
+        sys.exit(2)
+    if not os.path.isfile(args.fasta_file):
+        print(f"FASTA file does not exist: {args.fasta_file}", file=sys.stderr)
+        sys.exit(2)
+
+    grg = pygrgl.load_mutable_grg(args.grg_input, load_up_edges=True)
+    if grg is None:
+        print(f"Failed to load GRG: {args.grg_input}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        stats = polarize_grg_from_fasta(
+            grg,
+            args.fasta_file,
+            drop_if_no_match=not args.keep_no_match,
+            map_batch_size=args.map_batch_size,
+        )
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        sys.exit(2)
+
+    pygrgl.save_grg(grg, args.output_file)
+
+    print("Polarization complete")
+    print(f"  Total seen:           {stats.total_seen}")
+    print(f"  Emitted:              {stats.emitted}")
+    print(f"  Already polarized:    {stats.already_polarized}")
+    print(f"  Swapped:              {stats.swapped}")
+    print(f"  Inconsistent:         {stats.inconsistent}")
+    print(f"  After alignment end:  {stats.after_alignment}")
+    print(f"  Alignment mismatch:   {stats.no_alignment}")
+    print(f"  Non-SNVs skipped:     {stats.non_snv_skipped}")
+    print(f"  Missingness remapped: {stats.missing_remapped}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    add_options(parser)
+    args = parser.parse_args()
+    run(args)

--- a/grapp/popgen/polarize.py
+++ b/grapp/popgen/polarize.py
@@ -1,0 +1,377 @@
+from dataclasses import dataclass, field
+from grapp.util.exceptions import UserInputError
+from typing import List
+import numpy
+import pygrgl
+
+MISSING_ALLELE = "."
+UNKNOWN_ALLELES = {".", "-", "N"}
+DEFAULT_BATCH_SIZE = 100
+
+
+@dataclass
+class PolarizationStats:
+    unpolarized: List[int] = field(default_factory=list)
+    total_seen: int = 0
+    emitted: int = 0
+    already_polarized: int = 0
+    swapped: int = 0
+    inconsistent: int = 0
+    after_alignment: int = 0
+    no_alignment: int = 0
+    non_snv_skipped: int = 0
+    missing_remapped: int = 0
+
+
+@dataclass(frozen=True)
+class SiteSwap:
+    entries: list
+    swap_index: int
+    ancestral_allele: str
+
+
+def get_descendant_samples(grg, node_id):
+    if node_id == pygrgl.INVALID_NODE:
+        return numpy.array([], dtype=numpy.uint32)
+    descendants = pygrgl.get_bfs_order(grg, pygrgl.TraversalDirection.DOWN, [node_id])
+    return numpy.fromiter(
+        (node for node in descendants if node < grg.num_samples),
+        dtype=numpy.uint32,
+    )
+
+
+# apply all remaps in a batch (can be from multiple sites)
+def apply_remaps(grg, removals, remap_mutations, remap_samples, map_batch_size):
+    if not removals and not remap_mutations:
+        return
+
+    list(grg.get_node_mutation_miss())
+    for mut_id, node_id in removals:
+        grg.remove_mutation(mut_id, node_id)
+
+    if remap_mutations:
+        pygrgl.map_mutations(
+            grg,
+            remap_mutations,
+            remap_samples,
+            verbose=False,
+            mutation_batch_size=map_batch_size,
+        )
+
+
+# compute mutation removals and remaps for one site
+def build_site_swap_remaps(grg, site_swaps, map_batch_size, stats):
+    if not site_swaps:
+        return [], [], []
+
+    removals = []
+    remap_mutations = []
+    remap_samples = []
+
+    site_state = []
+    flat_entries = []
+    for site_index, site_swap in enumerate(site_swaps):
+        entries = site_swap.entries
+        swap_mutation = entries[site_swap.swap_index][3]
+        has_missing = any(entry[2] != pygrgl.INVALID_NODE for entry in entries)
+        site_state.append(
+            {
+                "ancestral_allele": site_swap.ancestral_allele,
+                "old_ref": entries[0][3].ref_allele,
+                "position": int(entries[0][3].position),
+                "time": swap_mutation.time,
+                "unavailable": numpy.zeros(grg.num_samples, dtype=bool),
+                "full_remap": has_missing,
+            }
+        )
+        for row_index, entry in enumerate(entries):
+            flat_entries.append((site_index, row_index, site_swap.swap_index, entry))
+
+    for start in range(0, len(flat_entries), map_batch_size):
+        entry_batch = flat_entries[start : start + map_batch_size]
+
+        for site_index, row_index, swap_index, entry in entry_batch:
+            _mut_id, _node_id, _missing_node_id, mutation = entry
+            state = site_state[site_index]
+            carriers = get_descendant_samples(grg, _node_id)
+            state["unavailable"][carriers] = True
+
+            if row_index == swap_index:
+                removals.append((_mut_id, _node_id))
+                missing = get_descendant_samples(grg, _missing_node_id)
+                state["unavailable"][missing] = True
+                if len(missing) > 0:
+                    remap_mutations.append(
+                        pygrgl.Mutation(
+                            state["position"],
+                            MISSING_ALLELE,
+                            state["ancestral_allele"],
+                            state["time"],
+                        )
+                    )
+                    remap_samples.append(missing.tolist())
+                    stats.missing_remapped += 1
+            else:
+                updated_mutation = pygrgl.Mutation(
+                    state["position"],
+                    mutation.allele,
+                    state["ancestral_allele"],
+                    mutation.time,
+                )
+                if state["full_remap"]:
+                    removals.append((_mut_id, _node_id))
+                    remap_mutations.append(updated_mutation)
+                    remap_samples.append(carriers.tolist())
+                else:
+                    grg.set_mutation_by_id(_mut_id, updated_mutation)
+
+    for state in site_state:
+        old_ref_carriers = numpy.flatnonzero(~state["unavailable"]).astype(numpy.uint32)
+        remap_mutations.append(
+            pygrgl.Mutation(
+                state["position"],
+                state["old_ref"],
+                state["ancestral_allele"],
+                state["time"],
+            )
+        )
+        remap_samples.append(old_ref_carriers.tolist())
+
+    return removals, remap_mutations, remap_samples
+
+
+# determine whether a site is already polarized or needs a swap
+def classify_site(
+    site_entries,
+    ancestral_sequence,
+    stats,
+    drop_if_no_match,
+    removals,
+    site_swaps,
+):
+    if not site_entries:
+        return
+
+    position = int(site_entries[0][3].position)
+    old_ref = site_entries[0][3].ref_allele
+    stats.total_seen += len(site_entries)
+
+    if len(old_ref) != 1 or any(
+        len(mutation.allele) != 1
+        for _mut_id, _node_id, _missing_node_id, mutation in site_entries
+    ):
+        stats.non_snv_skipped += len(site_entries)
+        stats.unpolarized.append(position)
+        if drop_if_no_match:
+            removals.extend(
+                (mut_id, node_id)
+                for mut_id, node_id, _missing_node_id, _mutation in site_entries
+            )
+        return
+
+    if ancestral_sequence is None:
+        stats.after_alignment += 1
+        stats.unpolarized.append(position)
+        if drop_if_no_match:
+            removals.extend(
+                (mut_id, node_id)
+                for mut_id, node_id, _missing_node_id, _mutation in site_entries
+            )
+        return
+
+    ancestral_sequence = ancestral_sequence.upper()
+    if ancestral_sequence[0] in UNKNOWN_ALLELES:
+        stats.no_alignment += 1
+        stats.unpolarized.append(position)
+        if drop_if_no_match:
+            removals.extend(
+                (mut_id, node_id)
+                for mut_id, node_id, _missing_node_id, _mutation in site_entries
+            )
+        return
+
+    matches = []
+    if allele_matches_ancestral(old_ref, ancestral_sequence):
+        matches.append((-1, old_ref))
+
+    for idx, (_mut_id, _node_id, _missing_node_id, mutation) in enumerate(site_entries):
+        if allele_matches_ancestral(mutation.allele, ancestral_sequence):
+            matches.append((idx, mutation.allele))
+
+    if not matches:
+        stats.inconsistent += len(site_entries)
+        stats.unpolarized.append(position)
+        if drop_if_no_match:
+            removals.extend(
+                (mut_id, node_id)
+                for mut_id, node_id, _missing_node_id, _mutation in site_entries
+            )
+        return
+
+    swap_index, ancestral_allele = max(matches, key=lambda item: len(item[1]))
+
+    if swap_index < 0:
+        stats.already_polarized += len(site_entries)
+        stats.emitted += len(site_entries)
+        return
+
+    stats.swapped += 1
+    stats.emitted += len(site_entries)
+    site_swaps.append(
+        SiteSwap(list(site_entries), swap_index, ancestral_allele.upper())
+    )
+
+
+def build_mut_lookup(grg):
+    mut_lookup = [None] * grg.num_mutations
+    for mut_id, node_id, missing_node_id in grg.get_mutation_node_miss():
+        mut_lookup[int(mut_id)] = (int(node_id), int(missing_node_id))
+    return mut_lookup
+
+
+def fetch_ancestral(sequence, position, length):
+    if length <= 0:
+        return None
+    if position <= 0:
+        return None
+    if position + length - 1 > len(sequence):
+        return None
+    return sequence[position - 1 : position - 1 + length]
+
+
+def equals_ignore_case(left, right):
+    return left.upper() == right.upper()
+
+
+def allele_matches_ancestral(allele, ancestral_sequence):
+    return (
+        bool(allele)
+        and len(allele) <= len(ancestral_sequence)
+        and equals_ignore_case(
+            allele,
+            ancestral_sequence[: len(allele)],
+        )
+    )
+
+
+def polarize_grg(
+    grg: pygrgl.MutableGRG,
+    ancestral_seq: str,
+    drop_if_no_match: bool = True,
+    map_batch_size: int = DEFAULT_BATCH_SIZE,
+):
+    if map_batch_size <= 0:
+        raise UserInputError("map_batch_size must be greater than zero")
+
+    stats = PolarizationStats()
+    mut_lookup = build_mut_lookup(grg)
+    total_mutations = grg.num_mutations
+    site_entries = []  # type: ignore
+    site_key = None
+    pending_removals = []  # type: ignore
+    pending_site_swaps = []  # type: ignore
+    pending_swap_entry_count = 0
+    pending_map_removals = []
+    pending_remap_mutations = []
+    pending_remap_samples = []
+
+    def materialize_site_swaps():
+        nonlocal pending_swap_entry_count
+        if not pending_site_swaps:
+            return
+        site_removals, remap_mutations, remap_samples = build_site_swap_remaps(
+            grg, pending_site_swaps, map_batch_size, stats
+        )
+        pending_map_removals.extend(site_removals)
+        pending_remap_mutations.extend(remap_mutations)
+        pending_remap_samples.extend(remap_samples)
+        pending_site_swaps.clear()
+        pending_swap_entry_count = 0
+
+    def flush_remaps():
+        if not pending_map_removals and not pending_remap_mutations:
+            return
+        apply_remaps(
+            grg,
+            pending_map_removals,
+            pending_remap_mutations,
+            pending_remap_samples,
+            map_batch_size,
+        )
+        pending_map_removals.clear()
+        pending_remap_mutations.clear()
+        pending_remap_samples.clear()
+
+    def flush_pending(force=False):
+        if force:
+            materialize_site_swaps()
+            if pending_remap_mutations:
+                pending_map_removals[:0] = pending_removals
+                pending_removals.clear()
+                flush_remaps()
+            elif pending_removals:
+                apply_remaps(grg, pending_removals, [], [], map_batch_size)
+                pending_removals.clear()
+            return
+
+        if pending_swap_entry_count >= map_batch_size:
+            materialize_site_swaps()
+        if len(pending_remap_mutations) >= map_batch_size:
+            pending_map_removals[:0] = pending_removals
+            pending_removals.clear()
+            flush_remaps()
+            return
+        if (
+            pending_removals
+            and not pending_site_swaps
+            and len(pending_removals) >= map_batch_size
+        ):
+            apply_remaps(grg, pending_removals, [], [], map_batch_size)
+            pending_removals.clear()
+
+    def flush_site():
+        nonlocal pending_swap_entry_count
+        if not site_entries:
+            return
+        previous_swap_count = len(pending_site_swaps)
+        position = int(site_entries[0][3].position)
+        # TODO: it might be simpler to just append a "-" to the 0th position of ancestral_sequence?
+        # Then all the indexing will match between FASTA and GRG.
+        ancestral = fetch_ancestral(ancestral_seq, position, 1)
+        classify_site(
+            site_entries,
+            ancestral,
+            stats,
+            drop_if_no_match,
+            pending_removals,
+            pending_site_swaps,
+        )
+        if len(pending_site_swaps) > previous_swap_count:
+            pending_swap_entry_count += len(site_entries)
+        flush_pending()
+
+    for mut_id in range(total_mutations):
+        mutation = grg.get_mutation_by_id(mut_id)
+        if mutation.allele == MISSING_ALLELE:
+            continue
+
+        lookup_entry = mut_lookup[mut_id]
+        if lookup_entry is None:
+            continue
+
+        node_id, missing_node_id = lookup_entry
+        if node_id == pygrgl.INVALID_NODE:
+            continue
+
+        key = (int(mutation.position), mutation.ref_allele)
+        if site_key is not None and key != site_key:
+            flush_site()
+            site_entries.clear()
+        site_key = key
+        site_entries.append((mut_id, node_id, missing_node_id, mutation))
+
+    flush_site()
+    flush_pending(force=True)
+
+    grg.sort_mutations()
+    return stats

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 grg_pheno_sim>=1.4
 numpy
 pandas
+pyfaidx
 pygrgl>=2.7
 pyigd>=1.3
 scikit-learn

--- a/test/input/multi.vcf
+++ b/test/input/multi.vcf
@@ -1,0 +1,22 @@
+##fileformat=VCFv4.2
+##source=TESTING
+##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1|1:43:5:.,.
+20	14370	rs6054257	G	AC	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1|1:43:5:.,.
+20	14370	rs6054257	G	CA	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1|1:43:5:.,.
+20	14370	rs6054257	TG	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1|1:43:5:.,.
+20	17330	.	T	A	3	q10	NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0|.:41:3
+20	1110696	rs6040355	A	G,T	67	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	1|2:21:6:23,27	2|.:2:0:18,2	2|2:35:4

--- a/test/popgen/test_polarize.py
+++ b/test/popgen/test_polarize.py
@@ -1,0 +1,76 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import numpy as np
+import pygrgl
+from pygrgl.clicmd.common import which
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(THIS_DIR, ".."))
+from testing_utils import construct_grg
+
+INPUT_DIR = os.path.join(THIS_DIR, "..", "input")
+
+
+class TestPolarize(unittest.TestCase):
+    def test_multiallelic_snv_site_from_vcf(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_vcf = os.path.join(INPUT_DIR, "multi.vcf")
+            ancestral_fasta = os.path.join(tmpdir, "ancestor.fa")
+            input_grg = os.path.join(tmpdir, "multi.grg")
+            output_grg = os.path.join(tmpdir, "multi.polar.grg")
+
+            seq = ["N"] * 1110700
+            seq[14370 - 1] = "G"
+            seq[17330 - 1] = "A"
+            seq[1110696 - 1] = "T"
+            with open(ancestral_fasta, "w") as out:
+                out.write(">20\n")
+                sequence = "".join(seq)
+                for start in range(0, len(sequence), 80):
+                    out.write(sequence[start : start + 80] + "\n")
+
+            construct_grg(input_vcf, input_grg, ignore_missing=True)
+            # TODO: this should probably use the polarize_grg() API instead of the command line
+            subprocess.check_call(
+                [
+                    "grapp",
+                    "polarize",
+                    input_grg,
+                    ancestral_fasta,
+                    "-o",
+                    output_grg,
+                    "--map-batch-size",
+                    "2",
+                ]
+            )
+
+            grg = pygrgl.load_mutable_grg(output_grg, load_up_edges=True)
+            values = np.eye(grg.num_mutations, dtype=np.int32)
+            sample_matrix = pygrgl.matmul(grg, values, pygrgl.TraversalDirection.DOWN)
+
+            observed = {}
+            for mut_id in range(grg.num_mutations):
+                mutation = grg.get_mutation_by_id(mut_id)
+                observed[
+                    (int(mutation.position), mutation.ref_allele, mutation.allele)
+                ] = tuple(
+                    int(sample_id)
+                    for sample_id in np.flatnonzero(sample_matrix[mut_id] > 0)
+                )
+
+            self.assertEqual(
+                observed,
+                {
+                    (17330, "A", "T"): (0, 1, 2, 4, 5),
+                    (1110696, "T", "A"): (3,),
+                    (1110696, "T", "G"): (0,),
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/testing_utils.py
+++ b/test/testing_utils.py
@@ -23,6 +23,7 @@ def construct_grg(
     output_file: Optional[str] = None,
     jobs: int = 6,
     is_test_input: bool = True,
+    ignore_missing: bool = False,
 ) -> str:
     cmd = [
         "grg",
@@ -34,6 +35,8 @@ def construct_grg(
         str(jobs),
         os.path.join(INPUT_DIR, input_file) if is_test_input else input_file,
     ]
+    if ignore_missing:
+        cmd.append("--ignore-missing")
     if output_file is not None:
         cmd.extend(["-o", output_file])
     else:


### PR DESCRIPTION
This branch adds the polarization workflow, which uses an ancestral FASTA to reorient mutation alleles in a GRG. It identifies sites whose reference/derived alleles need to be swapped, updates those mutations, remaps affected carriers, and preserves output consistency through the existing mutation-mapping pipeline.