### PR TITLE
Docs and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ on top of the Genotype Representation Graph (GRG) format. [GRG](https://github.c
 a file format and data structure that losslessly represents a genetic dataset. It has the advantage of
 compressing large datasets significantly, while also making calculations over that dataset extremely fast
 (see [the paper](https://www.nature.com/articles/s43588-024-00739-9) and the
-[core library](https://github.com/aprilweilab/grgl)).
+[main GRG documentation](https://grgl.readthedocs.io/en/latest/index.html)).
 
 Some notes on usage are below, and you can also browse [the Python documentation for grapp](https://grapp.readthedocs.io/en/latest/).
 
@@ -146,7 +146,7 @@ mutation filters:
 
 #### Library
 
-Library API reference document is [here](https://grapp.readthedocs.io/en/latest/). There are also some tutorials in the [GRG documentation](https://grgl.readthedocs.io/en/stable/tutorials/GWAS.html) (and correspond [Jupyter notebooks](https://github.com/aprilweilab/grgl/tree/main/doc/tutorials/notebooks)).
+Library API reference document is [here](https://grapp.readthedocs.io/en/latest/). There are also some tutorials in the [GRG documentation](https://grgl.readthedocs.io/en/latest/tutorials/GWAS.html) (and correspond [Jupyter notebooks](https://github.com/aprilweilab/grgl/tree/main/doc/tutorials/notebooks)).
 
 ### nn
 

--- a/docs/compatible.rst
+++ b/docs/compatible.rst
@@ -1,0 +1,33 @@
+Compatible Libraries
+====================
+
+A list of Python libraries, beyond just `numpy <http://numpy.org/>`_ and `pandas <http://pandas.pydata.org/>`_, providing
+mathematical algorithms that are compatible with grapp's :py:class:`LinearOperator` interface.
+
+scipy
+-----
+
+Many of the functions in the `scipy.sparse.linalg <https://docs.scipy.org/doc/scipy/reference/sparse.linalg.html>`_ module
+are compatible with ``LinearOperator``. Of particular note are:
+
+ * The conjugate gradient method `scipy.sparse.linalg.cg <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.cg.html#scipy.sparse.linalg.cg>`_
+ * Least squares solver `scipy.sparse.linalg.lsqr <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.cg.html#scipy.sparse.linalg.lsqr>`_
+ * Eigenvalue decomposition via `scipy.sparse.linalg.eigs <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.cg.html#scipy.sparse.linalg.eigs>`_
+ * The preconditioned eigensolver `scipy.sparse.linalg.lobpcg <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.cg.html#scipy.sparse.linalg.lobpcg>`_
+
+
+PyLops
+------
+
+`PyLops <http://pylops.readthedocs.io/>`_ is a library focused on matrix-free methods, primarily focused on signal processing, but with some general purpose methods as well.
+The grapp ``LinearOperator`` classes are compatible with PyLops. Of particular note are:
+
+ * The HutchPP estimator for the trace of a matrix, `pylops.utils.estimators.trace_hutchpp <https://pylops.readthedocs.io/en/stable/api/generated/pylops.utils.estimators.trace_hutchpp.html#pylops.utils.estimators.trace_hutchpp>`_
+ * Combining multiple ``LinearOperator`` via `pylops.HStack <https://pylops.readthedocs.io/en/stable/api/generated/pylops.HStack.html>`_, `pylops.VStack <https://pylops.readthedocs.io/en/stable/api/generated/pylops.VStack.html>`_, and `pylops.BlockDiag <https://pylops.readthedocs.io/en/stable/api/generated/pylops.BlockDiag.html>`_
+ * Kronecker product of ``LinearOperator`` via `pylops.Kronecker <https://pylops.readthedocs.io/en/stable/api/generated/pylops.Kronecker.html>`_
+ * Various optimization solvers with forced sparsity, such as `pylops.optimization.cls_sparsity.FISTA <https://pylops.readthedocs.io/en/stable/api/generated/pylops.optimization.cls_sparsity.FISTA.html>`_
+
+spgl1
+-----
+
+`spgl1 <https://spgl1.readthedocs.io/en/latest/>`_ is a regularized least-squares solver (e.g., LASSO) that is compatible with ``LinearOperator``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 
 # Nasty workaround for RTD being annoying to test with. There is probably a better

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -1,0 +1,178 @@
+File Formats
+============
+
+The command line interface to grapp primarily reads and writes tab-separated text files.
+
+Phenotype Inputs
+----------------
+
+Phenotypes can be input to ``grapp`` in three different formats:
+
+ * `plink-style text file <https://www.cog-genomics.org/plink/1.9/input#pheno>`_
+ * Tab-separate value file (TSV), compatible with ``pandas.read_csv(filename, delimiter="\t")``
+   * With a single column. The phenotype values only, and the order is assumed to be the individual order.
+   * With two columns. The individual ID and phenotype values; the order is still assumed to be the individual order, but the individual ID is used to verify correctness of the order.
+
+plink-style
+~~~~~~~~~~~
+
+Text file with optional header line, FID and IID in first two columns, phenotypes in the third column.
+The first column (FID) is ignored. The IID column is ignored if it has the value NA, otherwise it is cross-checked against
+the order of individual IDs in the GRG file. That is, the *order* of the covariates file must correspond to the order of the individuals
+as indexed in the GRG, and if IIDs are provided then ``grapp`` will confirm that this order is correct and reject the input otherwise.
+
+Example:
+
+::
+
+  FID IID PHENOTYPE_A
+  0 tsk_9 3.14
+  IGNORED tsk_2 54.123
+
+pandas-style
+~~~~~~~~~~~~
+
+Style1 has two columns, the individual ID and the phenotype:
+
+::
+
+   individual_id phenotypes
+   tsk_1 1.19
+   tsk_2 99
+
+The header is optional, so this is also valid:
+
+::
+
+   tsk_1 1.19
+   tsk_2 99
+
+The individual ID is also optional, so this is also valid:
+
+::
+
+   1.19
+   99
+
+The disadvantage of this last, single column, format is that you don't get any sanity checking on the
+individual IDs against the order of samples within the GRG.
+
+Covariates Inputs
+-----------------
+
+Covariates can be input to ``grapp`` in two different formats:
+
+ * `plink-style text file <https://www.cog-genomics.org/plink/1.9/input#covar>`_
+ * Tab-separate value file (TSV), compatible with ``pandas.read_csv(filename, delimiter="\t")``
+
+You must provide a file with the correct file extension so that ``grapp`` knows which file type to use: ``.txt`` for plink-style,
+and ``.tsv`` for pandas-style.
+
+plink-style
+~~~~~~~~~~~
+
+Text file with optional header line, FID and IID in first two columns, covariates in remaining columns.
+The first column (FID) is ignored. The IID column is ignored if it has the value NA, otherwise it is cross-checked against
+the order of individual IDs in the GRG file. That is, the *order* of the covariates file must correspond to the order of the individuals
+as indexed in the GRG, and if IIDs are provided then ``grapp`` will confirm that this order is correct and reject the input otherwise.
+
+Example:
+
+::
+
+   FID IID SITE AGE DOB BMI SMOKE
+   0 tsk_0 11.1 2.1 3.0 100 99.999999
+   0 tsk_1 12.1 22.1 23.0 120 19.191919
+
+pandas-style
+~~~~~~~~~~~~
+
+You can also just use a tab-separate file, where each column is a covariate. There is no individual ID, the rows are ordered
+according to the order of the individuals (e.g., see ``grapp show -S`` to see the individual order in a GRG).
+
+Example:
+
+::
+
+   PC1     PC2     PC3     PC4     PC5
+   -0.02962050343353934    -0.1454314700126317     0.09400946258618631     0.049484006249728846    -0.047684090813491696
+   0.08143511260364325     -0.08589047179019427    0.02806784261156361     -0.03490721182219861    -0.008695950854523016
+   0.009043842123764047    0.05004380910616621     0.058859397426153766    -0.041742678498370434   0.021168181948134204
+   0.07220254903672255     0.006810145300172974    -0.19663115373847032    -0.022568831773233364   0.06676064188763692
+   -0.011695803933424008   0.0493589235771859      0.0364513132579304      0.06629422839731464     0.015111070046121165
+   0.05903374410746705     0.0643695785650203      -0.02606823869488902    0.040894123687997726    0.019502422077301032
+   0.03031031254694341     0.009922066597477694    -0.03350773443115891    0.05706756991552372     -0.19362734163613687
+
+
+Sample Filtering Inputs
+-----------------------
+
+By individual
+~~~~~~~~~~~~~
+
+Filter option:
+
+::
+
+  -S INDIVIDUALS, --individuals INDIVIDUALS
+                        Keep only the individuals with the IDs given as a comma-separated list or in the given filename.
+
+When providing a list of individuals in a file, there should be one individual ID per line with no extra whitespace. For example,
+here is a short input file for the `1,000 Genomes Project <https://www.internationalgenome.org/>`_ dataset that filters to a few individuals:
+
+::
+
+  HG00112
+  HG00121
+  HG00125
+  NA21090
+  NA21123
+  NA21107
+
+
+For this command to work, the GRG must have individual identifiers (e.g., the ``VCF`` or ``IGD`` file it was constructed from must have had them).
+
+The order of the individuals as provided will be their new order in the resulting GRG. E.g., individual ``0`` will be ``HG00112``, regardless of its
+order in the original GRG.
+
+By haplotype index
+~~~~~~~~~~~~~~~~~~
+
+Filter option:
+
+::
+
+  --hap-samples HAP_SAMPLES
+                        Keep only the haploid samples with the NodeIDs (indexes) given as a comma-separated list or in the given filename.
+
+When individual identifiers are unavailable, it may be desirable to filter by haplotype index (order of samples in the GRG) instead. The order of
+samples in the GRG always follows the original order from the dataset (e.g., the ``VCF`` or ``IGD`` file). For diploid data, each individual's
+two haplotype samples are sequential in order. E.g., diploid individual ``0`` maps to haplotype indices ``0, 1``, individual ``1`` maps to
+indices ``2, 3``, etc.
+
+When providing a list of haplotype indices by file, there should be one index per line. Each index must be an integer. For example, this input
+file selects 4 diploid individuals by their haplotype indices:
+
+::
+
+  50
+  51
+  0
+  1
+  8
+  9
+  32
+  33
+
+The order of the haplotypes as provided will be their new order in the resulting GRG. E.g., sample ``0`` in the new GRG will be ``50`` from the old GRG, etc.
+
+
+Polarization Inputs
+-------------------
+
+Polarization requires an ancestral sequence as input, in `FASTA format <https://en.wikipedia.org/wiki/FASTA_format>`_. grapp requires that
+the FASTA file contains a single sequence, which represents the ancestral state of each nucleotide. The FASTA file is assumed to be 1-based
+indexing, which means that the first nucleotide in the sequence is for base-pair position ``1`` (not ``0``).  There is no case expectation
+for the sequence: lower and upper should both work.
+
+We use the excellent `pyfaidx <https://pypi.org/project/pyfaidx/>`_ library for FASTA parsing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,14 @@
 grapp Documentation
 ===================
 
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
    API Reference <grapp>
+   Tool File Formats <formats>
+   Compatible Math Libraries <compatible>
 
 grapp is a Python library for performing highly scalable, highly efficient calculations on
 (GRG) files. `GRG is a graph-based data structure and file format format <https://grgl.readthedocs.io/en/stable/concepts.html>`_.
@@ -18,6 +21,8 @@ grapp is both a tool set and a framework:
 
 Both integrate nicely with the Python data analysis ecosystem of `numpy <https://numpy.org>`_, `pandas <https://pandas.pydata.org>`_, and `scipy <https://scipy.org>`_.
 
+The main GRG documentation contains some `tutorials <https://grgl.readthedocs.io/en/stable/tutorials/GWAS.html>`_ on using ``grapp`` for tasks like
+`GWAS <https://grgl.readthedocs.io/en/stable/tutorials/GWAS.html>`_, `PCA <https://grgl.readthedocs.io/en/stable/tutorials/PCA.html>`_, and `LinearOperators <https://grgl.readthedocs.io/en/stable/tutorials/LinearOperators.html>`_, among other tasks.
 
 
 Indices and tables

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ pygrgl
 pyigd
 scipy
 scikit-learn
-sphinx-rtd-theme
+pydata-sphinx-theme

--- a/grapp/assoc/__init__.py
+++ b/grapp/assoc/__init__.py
@@ -6,7 +6,7 @@ from grapp.grg_calculator import (
     _wrap_grg,
 )
 from scipy.stats import t as t_distribution
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 import itertools
 import math
 import numpy
@@ -29,42 +29,89 @@ def _div_or_default(a, b, d):
     return numpy.divide(a, b, out=result, where=(b != 0))
 
 
-def read_plink_covariates(covar_path: str) -> numpy.typing.NDArray:
+def read_plink_covariates(
+    covar_path: str, return_indivs: bool = False, verbose: bool = False
+) -> Union[numpy.typing.NDArray, Tuple[numpy.typing.NDArray, List[str]]]:
     """
-    Reads a PLINK-style covariate file (no headers) and returns a NumPy matrix of covariate values.
-    The first two columns (FID/IID) are ignored. Optionally adds an intercept column of 1s.
+    Reads a PLINK-style covariate file: Optional header line, FID and IID in first two columns,
+    covariates in remaining columns. The first two columns (FID/IID) are ignored. Does not allow
 
     :param path: Path to the covariate file.
     :type path: str
-    :return: A NumPy array of shape (n_samples, n_covariates [+1 if intercept]).
-    :rtype: numpy.ndarray
+    :param return_indivs: If True, return a list of individual identifiers (IIDs from the plink file).
+    :type return_indivs: bool
+    :param verbose: Emit warnings/information about the file if True. Default: True.
+    :type verbose: bool
+    :return: The covariates as a numpy array of shape (n_samples, n_covariates). If return_indivs is True, then also
+        return a list of individual IDs (strings).
+    :rtype: Union[numpy.typing.NDArray, Tuple[numpy.typing.NDArray, List[str]]]
     """
     rows = []
+    num_covar = 0
+    covar_names = []
+    iids = []
     with open(covar_path, "r") as f:
-        for line in f:
+        for i, line in enumerate(f):
             parts = line.strip().split()
             if not parts:
                 continue
-            # skip FID/IID, keep covariates
-            cov_vals = [float(v) for v in parts[2:]]
-            rows.append(cov_vals)
+            if i == 0 and parts[0] == "FID":
+                assert (
+                    len(parts) > 1 and parts[1] == "IID"
+                ), "Header line must include FID followed by IID."
+                covar_names = parts[2:]
+                num_covar = len(covar_names)
+            else:
+                cov_vals = [float(v) for v in parts[2:]]
+                if num_covar == 0:
+                    num_covar = len(cov_vals)
+                assert num_covar == len(
+                    cov_vals
+                ), f"Inconsistent number of columns in covariates file (line: {i}, cols: {len(cov_vals)})"
+                rows.append(cov_vals)
+                iids.append(parts[1])
+    assert num_covar > 0, "No covariates are present in the file (only two columns)."
 
     # stack into (n_samples × K)
     X = numpy.vstack(rows) if rows else numpy.empty((0, 0))
 
+    if verbose:
+        print(f"Loaded {num_covar} covariates for {len(rows)} individuals")
+        if covar_names:
+            print(f"Covariate names: {covar_names}")
+    if return_indivs:
+        return (X, iids)
     return X
 
 
-def read_pheno(filename: str, verbose: bool = True) -> numpy.typing.NDArray:
+def read_pheno(
+    filename: str, return_indivs: bool = False, verbose: bool = True
+) -> Union[numpy.typing.NDArray, Tuple[numpy.typing.NDArray, List[str]]]:
     """
-    Reads a PLINK/GCTA/GRG-style phenotype file and returns the phenotype vector.
+    Reads a PLINK/GCTA/GRG-style phenotype file and returns the phenotype vector. In all cases, the
+    row order of the file must match the individual indexing order of the GRG.
+
+    PLINK-style: Optional header "FID IID PHEN". The first column is the family ID (ignored by grapp),
+    the second column is the IID (used for validation by grapp), and the third column in the numerical
+    phenotype value. The IID order is checked against the GRG individual ID order, when IDs are present
+    in the GRG (and also not "NA" in the plink input file).
+
+    GRG-style: Optional header "person_id phenotypes". The first column is checked against the GRG individual
+    ID order, when IDs are present in GRG (and also not "NA" in the phenotype file). The second column is
+    the numerical phenotype value.
+
+    If there is no header, the number of columns determines the type (3 = plink, 2 = GRG).
+
+    In all cases, columns can be tab-separated or space separated.
 
     :param path: Path to the phenotype file.
     :type path: str
+    :param return_indivs: If True, return a list of individual identifiers (IIDs from the plink file).
+    :type return_indivs: bool
     :param verbose: Emit warnings/information about the file if True. Default: True.
     :type verbose: bool
     :return: A one-dimensional NumPy array of phenotype values.
-    :rtype: numpy.ndarray
+    :rtype: Union[numpy.typing.NDArray, Tuple[numpy.typing.NDArray, List[str]]]
     """
     header_line = None
     with open(filename, "r") as f:
@@ -77,32 +124,53 @@ def read_pheno(filename: str, verbose: bool = True) -> numpy.typing.NDArray:
             header_line = i
             break
         # grg_pheno_sim header
-        if re.match(r"^(person_id\tphenotypes)", line.strip(), re.IGNORECASE):
+        if re.match(r"^((person_id|individual_id)\s+(phenotypes|phenotype))", line.strip(), re.IGNORECASE):
             header_line = i
             break
 
     # Read data starting from the header (if present)
     if header_line is not None:
         df = pandas.read_csv(
-            filename, sep=r"\s+", skiprows=header_line, engine="python"
+            filename,
+            sep=r"\s+",
+            skiprows=header_line,
+            engine="python",
+            skipinitialspace=True,
+            na_filter=False,
         )
     else:
-        df = pandas.read_csv(filename, sep=r"\s+", header=None, engine="python")
+        df = pandas.read_csv(
+            filename,
+            sep=r"\s+",
+            header=None,
+            engine="python",
+            skipinitialspace=True,
+            na_filter=False,
+        )
 
     # Check column count
-    if df.shape[1] not in (2, 3):
-        raise ValueError(f"Expected 2 or 3 columns, but found {df.shape[1]}.")
+    if df.shape[1] > 3:
+        raise ValueError(f"Expected 1, 2, or 3 columns, but found {df.shape[1]}.")
 
     # Extract last column and make sure it's a number
     try:
         last_col = df.iloc[:, -1].astype(float).to_numpy()
     except ValueError:
-        raise ValueError("Last column contains non-numeric values.")
+        raise ValueError(
+            "Last column should be phenotype, but it contains non-numeric values."
+        )
     if verbose:
         print(
-            f"Using the column {df.shape[1]} (the last one) for phenotype.",
+            f"Using the {df.shape[1]}th column (the last one) for phenotype ({df.columns[-1]}).",
             file=sys.stderr,
         )
+
+    if return_indivs:
+        if len(df.columns) >= 2:
+            iids = df.iloc[:, -2].to_list()
+        else:
+            iids = ["NA"] * len(df)
+        return (last_col, iids)
 
     return last_col
 

--- a/grapp/assoc/__init__.py
+++ b/grapp/assoc/__init__.py
@@ -124,7 +124,11 @@ def read_pheno(
             header_line = i
             break
         # grg_pheno_sim header
-        if re.match(r"^((person_id|individual_id)\s+(phenotypes|phenotype))", line.strip(), re.IGNORECASE):
+        if re.match(
+            r"^((person_id|individual_id)\s+(phenotypes|phenotype))",
+            line.strip(),
+            re.IGNORECASE,
+        ):
             header_line = i
             break
 
@@ -136,7 +140,6 @@ def read_pheno(
             skiprows=header_line,
             engine="python",
             skipinitialspace=True,
-            na_filter=False,
         )
     else:
         df = pandas.read_csv(
@@ -145,7 +148,6 @@ def read_pheno(
             header=None,
             engine="python",
             skipinitialspace=True,
-            na_filter=False,
         )
 
     # Check column count

--- a/grapp/cli/assoc_cli.py
+++ b/grapp/cli/assoc_cli.py
@@ -92,9 +92,17 @@ def run(args):
     grgs = [load_grg_calculator(g) for g in args.grg_input]
     num_indivs = grgs[0].num_individuals
 
+    def notna(value):
+        if value == "NA":
+            return False
+        try:
+            return not numpy.isnan(value)
+        except TypeError:
+            return True
+
     def check_iid_order(iids: List[str], filetype: str):
         if not grgs[0].has_individual_ids:
-            nonna = list(filter(lambda x: x != "NA", iids))
+            nonna = list(filter(notna, iids))
             if len(nonna) > 0:
                 print(
                     f"WARNING! IIDs were provided in {filetype} file (e.g., {nonna[0]}), but GRG has no individual IDs to cross-check against.",

--- a/grapp/cli/assoc_cli.py
+++ b/grapp/cli/assoc_cli.py
@@ -7,12 +7,13 @@ from grapp.assoc import (
 from grapp.cli.util import pandas_to_tsv
 from grapp.grg_calculator import load_grg_calculator, GRGCalcInterface
 from grapp.util.exceptions import UserInputError
-from typing import Optional
+from typing import Optional, List
 import argparse
 import concurrent.futures
 import numpy
 import os
 import pandas
+import sys
 
 
 def add_options(subparser):
@@ -89,18 +90,41 @@ def do_single_gwas(
 
 def run(args):
     grgs = [load_grg_calculator(g) for g in args.grg_input]
+    num_indivs = grgs[0].num_individuals
+
+    def check_iid_order(iids: List[str], filetype: str):
+        if not grgs[0].has_individual_ids:
+            nonna = list(filter(lambda x: x != "NA", iids))
+            if len(nonna) > 0:
+                print(
+                    f"WARNING! IIDs were provided in {filetype} file (e.g., {nonna[0]}), but GRG has no individual IDs to cross-check against.",
+                    file=sys.stderr,
+                )
+        else:
+            for i in range(grgs[0].num_individuals):
+                assert iids[i] == "NA" or iids[i] == grgs[0].get_individual_id(
+                    i
+                ), f"The {i}th row of {filetype} file has an IID mismatch. Input file={iids[i]}, GRG={grgs[0].get_individual_id(0)}"
+
     if args.phenotypes is None:
         print("No phenotype provided; randomly generating phenotype values")
-        y = numpy.random.standard_normal(grgs[0].num_individuals)
+        y = numpy.random.standard_normal(num_indivs)
     else:
-        y = read_pheno(args.phenotypes)
+        y, iids = read_pheno(args.phenotypes, return_indivs=True, verbose=True)
         assert (
-            len(y) == grgs[0].num_individuals
-        ), f"Phenotype file had {len(y)} rows, expected {grgs[0].num_individuals}"
+            len(y) == num_indivs
+        ), f"Phenotype file had {len(y)} rows, expected {num_indivs}"
+        check_iid_order(iids, "phenotype")
 
     if args.covariates is not None:
         if args.covariates.endswith(".txt"):
-            C = read_plink_covariates(args.covariates)
+            C, iids = read_plink_covariates(
+                args.covariates, return_indivs=True, verbose=True
+            )
+            assert (
+                len(iids) == num_indivs
+            ), "Read {len(iids)} covariates, but GRG has {num_indivs} individuals"
+            check_iid_order(iids, "covariate")
         else:
             assert args.covariates.endswith(
                 ".tsv"

--- a/grapp/cli/pheno_cli.py
+++ b/grapp/cli/pheno_cli.py
@@ -1,6 +1,7 @@
 from grg_pheno_sim.phenotype import sim_phenotypes, convert_to_phen
 from grapp.cli.util import load_immutable
 import argparse
+import numpy
 import os
 
 
@@ -47,6 +48,9 @@ def run(args):
     base = os.path.basename(args.grg_input)
     output_path = f"{base}.phen"
     grg = load_immutable(args.grg_input, load_up_edges=False)
+    assert (
+        grg.ploidy == 2
+    ), "Phenotype simulation currently only supports diploid datasets"
     phenotypes = sim_phenotypes(
         grg,
         num_causal=args.num_causal,
@@ -58,6 +62,16 @@ def run(args):
         effect_path=args.save_effects,
         header=True,
     )
+    # Resolve individual indices to individual identifiers, if possible.
+    if (
+        phenotypes["individual_id"].dtype in (int, numpy.int32, numpy.uint32)
+        and grg.has_individual_ids
+    ):
+        phenotypes["individual_id"] = list(
+            map(grg.get_individual_id, phenotypes["individual_id"])
+        )
+    else:
+        phenotypes["individual_id"] = ["NA"] * len(phenotypes)
     if args.out_file is None:
         args.out_file = output_path
     convert_to_phen(phenotypes, args.out_file, include_header=True)

--- a/grapp/cli/show_cli.py
+++ b/grapp/cli/show_cli.py
@@ -66,6 +66,7 @@ def run(args):
         print(f"Samples: {grg.num_samples}")
         print(f"Individuals: {grg.num_individuals}")
         print(f"Phased? {'Yes' if grg.is_phased else 'No'}")
+        print(f"Ploidy: {grg.ploidy}")
         print(f"Nodes: {grg.num_nodes}")
         print(f"Edges: {grg.num_edges}")
         print(f"Has missing data?: {'Yes' if grg.has_missing_data else 'No'}")

--- a/grapp/grg_calculator.py
+++ b/grapp/grg_calculator.py
@@ -169,6 +169,15 @@ class GRGCalcInterface(ABC):
 
     @property
     @abstractmethod
+    def has_individual_ids(self) -> int:
+        pass
+
+    @abstractmethod
+    def get_individual_id(self, index: int) -> str:
+        pass
+
+    @property
+    @abstractmethod
     def num_mutations(self) -> int:
         pass
 
@@ -333,6 +342,13 @@ class GRGCalculator(GRGCalcInterface):
         return self.grg.num_individuals
 
     @property
+    def has_individual_ids(self) -> int:
+        return self.grg.has_individual_ids
+
+    def get_individual_id(self, index: int) -> str:
+        return self.grg.get_individual_id(index)
+
+    @property
     def num_mutations(self) -> int:
         return self.grg.num_mutations
 
@@ -427,6 +443,13 @@ class GRGSpMVCalculator(GRGCalcInterface):
     @property
     def num_individuals(self) -> int:
         return self._op.num_individuals
+
+    @property
+    def has_individual_ids(self) -> int:
+        return False  # TODO
+
+    def get_individual_id(self, index: int) -> str:
+        raise NotImplementedError("TODO")
 
     @property
     def num_mutations(self) -> int:

--- a/grapp/util/filter.py
+++ b/grapp/util/filter.py
@@ -36,18 +36,18 @@ def grg_save_individuals(
         grg = pygrgl.load_immutable_grg(grg_or_filename, load_up_edges=True)
     else:
         grg = grg_or_filename
+    id2index = {grg.get_individual_id(i): i for i in range(grg.num_individuals)}
     sample_nodes = []
-    id_set = set(individual_ids)
-    for i in range(grg.num_individuals):
-        indiv = grg.get_individual_id(i)
-        if indiv in id_set:
-            base_sample = i * grg.ploidy
+    for kept_id in individual_ids:
+        index = id2index.get(kept_id)
+        if index is None:
+            if not allow_extra:
+                raise UserInputError(
+                    f"Found individual that was not in the GRG: {kept_id}"
+                )
+        else:
+            base_sample = index * grg.ploidy
             sample_nodes.extend(list(range(base_sample, base_sample + grg.ploidy)))
-            id_set.remove(indiv)
-    if not allow_extra and id_set:
-        raise UserInputError(
-            f"Found individuals that were not in the GRG: {','.join(id_set)}"
-        )
     if verbose:
         print(f"Keeping {len(sample_nodes)} haplotypes")
     pygrgl.save_subset(

--- a/test/assoc/test_helpers.py
+++ b/test/assoc/test_helpers.py
@@ -76,7 +76,6 @@ tsk_1 2.72
             self.assertEqual(indivs, indivs3)
             numpy.testing.assert_allclose(y, y3)
 
-
             # No header
             with open(phen_file, "w") as fout:
                 fout.write("""0 tsk_9 3.14
@@ -84,6 +83,15 @@ IGNORED tsk_2 54.123
 """)
             y, indivs = read_pheno(phen_file, return_indivs=True)
             self.assertEqual(indivs, ["tsk_9", "tsk_2"])
+            numpy.testing.assert_allclose(y, [3.14, 54.123])
+
+            # No header NA indivs
+            with open(phen_file, "w") as fout:
+                fout.write("""0 NA 3.14
+IGNORED NA 54.123
+""")
+            y, indivs = read_pheno(phen_file, return_indivs=True)
+            self.assertTrue(all(map(numpy.isnan, indivs)))
             numpy.testing.assert_allclose(y, [3.14, 54.123])
 
             # Single column
@@ -94,4 +102,3 @@ IGNORED tsk_2 54.123
             y, indivs = read_pheno(phen_file, return_indivs=True)
             self.assertEqual(indivs, ["NA", "NA"])
             numpy.testing.assert_allclose(y, [3.14, 54.123])
-

--- a/test/assoc/test_helpers.py
+++ b/test/assoc/test_helpers.py
@@ -1,0 +1,97 @@
+from grapp.assoc import read_pheno, read_plink_covariates
+import numpy
+import os
+import sys
+import tempfile
+import unittest
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(THIS_DIR, ".."))
+
+CLEANUP = True
+INPUT_DIR = os.path.join(THIS_DIR, "input")
+
+
+class TestAssocHelpers(unittest.TestCase):
+    def test_read_covars(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cv_file = os.path.join(tmpdir, "covars.txt")
+            with self.assertRaises(FileNotFoundError):
+                read_plink_covariates(cv_file)
+
+            # Header
+            with open(cv_file, "w") as fout:
+                fout.write("""FID IID SITE AGE DOB BMI SMOKE
+0 tsk_0 11.1 2.1 3.0 100 99.999999
+0 tsk_1 12.1 22.1 23.0 120 19.191919
+""")
+            C, indivs = read_plink_covariates(cv_file, return_indivs=True)
+            self.assertEqual(indivs, ["tsk_0", "tsk_1"])
+            numpy.testing.assert_allclose(C[0, :], [11.1, 2.1, 3.0, 100, 99.999999])
+            numpy.testing.assert_allclose(C[1, :], [12.1, 22.1, 23.0, 120, 19.191919])
+
+            # No header
+            with open(cv_file, "w") as fout:
+                fout.write("""0 tsk_9 3.14
+IGNORED tsk_2 54.123
+""")
+            C, indivs = read_plink_covariates(cv_file, return_indivs=True)
+            self.assertEqual(indivs, ["tsk_9", "tsk_2"])
+            numpy.testing.assert_allclose(C[0, :], [3.14])
+            numpy.testing.assert_allclose(C[1, :], [54.123])
+
+    def test_read_pheno(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            phen_file = os.path.join(tmpdir, "pheno.txt")
+            with self.assertRaises(FileNotFoundError):
+                read_pheno(phen_file)
+
+            # Plink-style Header
+            with open(phen_file, "w") as fout:
+                fout.write("""FID IID PHENOTYPE1
+0 tsk_0 1.109
+0 tsk_1 2.72
+""")
+            y, indivs = read_pheno(phen_file, return_indivs=True)
+            self.assertEqual(indivs, ["tsk_0", "tsk_1"])
+            numpy.testing.assert_allclose(y, [1.109, 2.72])
+
+            # GRG-style Header
+            with open(phen_file, "w") as fout:
+                fout.write("""person_id      phenotypes
+tsk_0     1.109
+tsk_1 2.72
+""")
+            y2, indivs2 = read_pheno(phen_file, return_indivs=True)
+            self.assertEqual(indivs, indivs2)
+            numpy.testing.assert_allclose(y, y2)
+
+            # GRG-style Header 2
+            with open(phen_file, "w") as fout:
+                fout.write("""individual_id      phenotypes
+tsk_0     1.109
+tsk_1 2.72
+""")
+            y3, indivs3 = read_pheno(phen_file, return_indivs=True)
+            self.assertEqual(indivs, indivs3)
+            numpy.testing.assert_allclose(y, y3)
+
+
+            # No header
+            with open(phen_file, "w") as fout:
+                fout.write("""0 tsk_9 3.14
+IGNORED tsk_2 54.123
+""")
+            y, indivs = read_pheno(phen_file, return_indivs=True)
+            self.assertEqual(indivs, ["tsk_9", "tsk_2"])
+            numpy.testing.assert_allclose(y, [3.14, 54.123])
+
+            # Single column
+            with open(phen_file, "w") as fout:
+                fout.write("""3.14
+54.123
+""")
+            y, indivs = read_pheno(phen_file, return_indivs=True)
+            self.assertEqual(indivs, ["NA", "NA"])
+            numpy.testing.assert_allclose(y, [3.14, 54.123])
+

--- a/test/assoc/test_helpers.py
+++ b/test/assoc/test_helpers.py
@@ -21,10 +21,11 @@ class TestAssocHelpers(unittest.TestCase):
 
             # Header
             with open(cv_file, "w") as fout:
-                fout.write("""FID IID SITE AGE DOB BMI SMOKE
+                contents = """FID IID SITE AGE DOB BMI SMOKE
 0 tsk_0 11.1 2.1 3.0 100 99.999999
 0 tsk_1 12.1 22.1 23.0 120 19.191919
-""")
+"""
+                fout.write(contents)
             C, indivs = read_plink_covariates(cv_file, return_indivs=True)
             self.assertEqual(indivs, ["tsk_0", "tsk_1"])
             numpy.testing.assert_allclose(C[0, :], [11.1, 2.1, 3.0, 100, 99.999999])
@@ -32,9 +33,10 @@ class TestAssocHelpers(unittest.TestCase):
 
             # No header
             with open(cv_file, "w") as fout:
-                fout.write("""0 tsk_9 3.14
+                contents = """0 tsk_9 3.14
 IGNORED tsk_2 54.123
-""")
+"""
+                fout.write(contents)
             C, indivs = read_plink_covariates(cv_file, return_indivs=True)
             self.assertEqual(indivs, ["tsk_9", "tsk_2"])
             numpy.testing.assert_allclose(C[0, :], [3.14])
@@ -48,57 +50,63 @@ IGNORED tsk_2 54.123
 
             # Plink-style Header
             with open(phen_file, "w") as fout:
-                fout.write("""FID IID PHENOTYPE1
+                contents = """FID IID PHENOTYPE1
 0 tsk_0 1.109
 0 tsk_1 2.72
-""")
+"""
+                fout.write(contents)
             y, indivs = read_pheno(phen_file, return_indivs=True)
             self.assertEqual(indivs, ["tsk_0", "tsk_1"])
             numpy.testing.assert_allclose(y, [1.109, 2.72])
 
             # GRG-style Header
             with open(phen_file, "w") as fout:
-                fout.write("""person_id      phenotypes
+                contents = """person_id      phenotypes
 tsk_0     1.109
 tsk_1 2.72
-""")
+"""
+                fout.write(contents)
             y2, indivs2 = read_pheno(phen_file, return_indivs=True)
             self.assertEqual(indivs, indivs2)
             numpy.testing.assert_allclose(y, y2)
 
             # GRG-style Header 2
             with open(phen_file, "w") as fout:
-                fout.write("""individual_id      phenotypes
+                contents = """individual_id      phenotypes
 tsk_0     1.109
 tsk_1 2.72
-""")
+"""
+                fout.write(contents)
             y3, indivs3 = read_pheno(phen_file, return_indivs=True)
             self.assertEqual(indivs, indivs3)
             numpy.testing.assert_allclose(y, y3)
 
             # No header
             with open(phen_file, "w") as fout:
-                fout.write("""0 tsk_9 3.14
+                contents = """0 tsk_9 3.14
 IGNORED tsk_2 54.123
-""")
+"""
+                fout.write(contents)
             y, indivs = read_pheno(phen_file, return_indivs=True)
             self.assertEqual(indivs, ["tsk_9", "tsk_2"])
             numpy.testing.assert_allclose(y, [3.14, 54.123])
 
             # No header NA indivs
             with open(phen_file, "w") as fout:
-                fout.write("""0 NA 3.14
+                contents = """0 NA 3.14
 IGNORED NA 54.123
-""")
+"""
+                fout.write(contents)
             y, indivs = read_pheno(phen_file, return_indivs=True)
             self.assertTrue(all(map(numpy.isnan, indivs)))
             numpy.testing.assert_allclose(y, [3.14, 54.123])
 
             # Single column
             with open(phen_file, "w") as fout:
-                fout.write("""3.14
+                contents = """3.14
 54.123
-""")
+"""
+                fout.write(contents)
             y, indivs = read_pheno(phen_file, return_indivs=True)
             self.assertEqual(indivs, ["NA", "NA"])
             numpy.testing.assert_allclose(y, [3.14, 54.123])

--- a/test/cli/test_filter.py
+++ b/test/cli/test_filter.py
@@ -17,6 +17,7 @@ class TestFilterCLI(unittest.TestCase):
     def setUpClass(cls):
         cls.grg_filename = construct_grg("test-200-samples.vcf.gz", "test.filtcli.grg")
 
+    @unittest.skip("Skip until pygrgl v2.10 is released")
     def test_filter_indivs(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             indivs_file = os.path.join(tmpdir, "indivs.txt")
@@ -35,6 +36,7 @@ class TestFilterCLI(unittest.TestCase):
             for i, ident in enumerate(indivs):
                 self.assertEqual(grg.get_individual_id(i), ident)
 
+    @unittest.skip("Skip until pygrgl v2.10 is released")
     def test_filter_haps(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             hap_file = os.path.join(tmpdir, "haps.txt")

--- a/test/cli/test_filter.py
+++ b/test/cli/test_filter.py
@@ -1,0 +1,66 @@
+import os
+import pygrgl
+import sys
+import tempfile
+import unittest
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(THIS_DIR, ".."))
+from testing_utils import construct_grg, grapp_run
+
+CLEANUP = True
+INPUT_DIR = os.path.join(THIS_DIR, "input")
+
+
+class TestFilterCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.grg_filename = construct_grg("test-200-samples.vcf.gz", "test.filtcli.grg")
+
+    def test_filter_indivs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            indivs_file = os.path.join(tmpdir, "indivs.txt")
+            grg_out = os.path.join(tmpdir, "out.grg")
+            indivs = ["tsk_10", "tsk_99", "tsk_13", "tsk_100", "tsk_58"]
+
+            with open(indivs_file, "w") as fout:
+                fout.write("\n".join(indivs))
+
+            grapp_run("filter", "-S", indivs_file, self.grg_filename, grg_out)
+            self.assertTrue(os.path.isfile(grg_out))
+            grg = pygrgl.load_immutable_grg(grg_out)
+            self.assertEqual(grg.ploidy, 2)
+            self.assertEqual(grg.num_samples, len(indivs) * 2)
+            self.assertEqual(grg.num_individuals, len(indivs))
+            for i, ident in enumerate(indivs):
+                self.assertEqual(grg.get_individual_id(i), ident)
+
+    def test_filter_haps(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hap_file = os.path.join(tmpdir, "haps.txt")
+            grg_out = os.path.join(tmpdir, "out.grg")
+
+            with open(hap_file, "w") as fout:
+                fout.write("""8
+9
+32
+33
+0
+1
+50
+51""")
+
+            grapp_run("filter", "--hap-samples", hap_file, self.grg_filename, grg_out)
+            self.assertTrue(os.path.isfile(grg_out))
+            grg = pygrgl.load_immutable_grg(grg_out)
+            self.assertEqual(grg.num_samples, 8)
+            self.assertEqual(grg.num_individuals, 4)
+            self.assertEqual(grg.get_individual_id(0), "tsk_4")
+            self.assertEqual(grg.get_individual_id(1), "tsk_16")
+            self.assertEqual(grg.get_individual_id(2), "tsk_0")
+            self.assertEqual(grg.get_individual_id(3), "tsk_25")
+
+    @classmethod
+    def tearDownClass(cls):
+        if CLEANUP:
+            os.remove(cls.grg_filename)

--- a/test/cli/test_filter.py
+++ b/test/cli/test_filter.py
@@ -43,14 +43,7 @@ class TestFilterCLI(unittest.TestCase):
             grg_out = os.path.join(tmpdir, "out.grg")
 
             with open(hap_file, "w") as fout:
-                fout.write("""8
-9
-32
-33
-0
-1
-50
-51""")
+                fout.write("\n".join([8, 9, 32, 33, 0, 1, 50, 51]))
 
             grapp_run("filter", "--hap-samples", hap_file, self.grg_filename, grg_out)
             self.assertTrue(os.path.isfile(grg_out))

--- a/test/cli/test_workflows.py
+++ b/test/cli/test_workflows.py
@@ -1,0 +1,81 @@
+"""
+Test some end-to-end workflows, e.g. generating phenotypes and covariates from grapp and then using
+them for grapp GWAS.
+"""
+
+import os
+import pandas
+import pygrgl
+import sys
+import tempfile
+import unittest
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(THIS_DIR, ".."))
+from testing_utils import construct_grg, grapp_run
+
+CLEANUP = True
+INPUT_DIR = os.path.join(THIS_DIR, "input")
+
+
+class TestCLIWorkflows(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.grg_filename = construct_grg(
+            "test-200-samples.vcf.gz", "test.cli_workflows.grg"
+        )
+
+    def test_pheno_to_gwas(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pheno_file = os.path.join(tmpdir, "test.phen")
+            print(grapp_run("pheno", "-o", pheno_file, self.grg_filename))
+            self.assertTrue(os.path.isfile(pheno_file))
+
+            gwas_results = os.path.join(tmpdir, "gwas.out.tsv")
+            print(
+                grapp_run(
+                    "assoc", "-p", pheno_file, "-o", gwas_results, self.grg_filename
+                )
+            )
+            self.assertTrue(os.path.isfile(gwas_results))
+            gwas_df = pandas.read_csv(gwas_results, delimiter="\t")
+            self.assertEqual(
+                gwas_df.columns.to_list(),
+                ["POS", "ALT", "REF", "COUNT", "BETA", "B0", "SE", "R2", "T", "P"],
+            )
+
+    def test_pheno_and_covar_to_gwas(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pheno_file = os.path.join(tmpdir, "test.phen")
+            print(grapp_run("pheno", "-o", pheno_file, self.grg_filename))
+            self.assertTrue(os.path.isfile(pheno_file))
+
+            cov_file = os.path.join(tmpdir, "test.cov.tsv")
+            print(grapp_run("pca", "-o", cov_file, self.grg_filename))
+            self.assertTrue(os.path.isfile(cov_file))
+
+            gwas_results = os.path.join(tmpdir, "gwas.out.tsv")
+            print(
+                grapp_run(
+                    "assoc",
+                    "-p",
+                    pheno_file,
+                    "-c",
+                    cov_file,
+                    "-o",
+                    gwas_results,
+                    self.grg_filename,
+                )
+            )
+            self.assertTrue(os.path.isfile(gwas_results))
+            gwas_df = pandas.read_csv(gwas_results, delimiter="\t")
+            # Covariates analysis does not have the intercept (intercept is always 1)
+            self.assertEqual(
+                gwas_df.columns.to_list(),
+                ["POS", "ALT", "REF", "COUNT", "BETA", "SE", "T", "P"],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        if CLEANUP:
+            os.remove(cls.grg_filename)

--- a/test/testing_utils.py
+++ b/test/testing_utils.py
@@ -7,6 +7,7 @@ import numpy
 import os
 import pygrgl
 import shutil
+import sys
 import subprocess
 
 try:
@@ -16,6 +17,7 @@ except ImportError:
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 INPUT_DIR = os.path.join(THIS_DIR, "input")
+REPO_ROOT = os.path.join(THIS_DIR, "..")
 
 
 def construct_grg(
@@ -200,3 +202,35 @@ def _wrap_grg_spmv(grg: Union[pygrgl.GRG, GRGCalcInterface]) -> GRGCalcInterface
 WRAP_GRG_PARAMS = [(lambda g: g,), (GRGCalculator,)]
 if _pygrgl_spmv is not None:
     WRAP_GRG_PARAMS.append((_wrap_grg_spmv,))
+
+
+def which(exe: str, required=False) -> Optional[str]:
+    """
+    Find an executable on $PATH or in the python system path.
+    """
+    try:
+        result = (
+            subprocess.check_output(["which", exe], stderr=subprocess.STDOUT)
+            .decode("utf-8")
+            .strip()
+        )
+    except subprocess.CalledProcessError:
+        result = None
+    if result is None:
+        for p in [*sys.path, REPO_ROOT]:
+            p = os.path.join(p, exe)
+            if os.path.isfile(p):
+                result = p
+                break
+    if required and result is None:
+        raise RuntimeError(f"Could not find executable {exe}")
+    return result
+
+
+GRAPP = which("grapp", required=True)
+
+
+def grapp_run(*command) -> str:
+    return subprocess.check_output(
+        [GRAPP] + list(command), stderr=subprocess.STDOUT
+    ).decode("utf-8")

--- a/test/testing_utils.py
+++ b/test/testing_utils.py
@@ -227,10 +227,10 @@ def which(exe: str, required=False) -> Optional[str]:
     return result
 
 
-GRAPP = which("grapp", required=True)
+MAIN_PY = os.path.join(REPO_ROOT, "grapp", "cli", "main.py")
 
 
 def grapp_run(*command) -> str:
     return subprocess.check_output(
-        [GRAPP] + list(command), stderr=subprocess.STDOUT
+        ["python", MAIN_PY] + list(command), stderr=subprocess.STDOUT
     ).decode("utf-8")


### PR DESCRIPTION
1. Add a list of libraries compatible with grapp's LinearOperator
2. Add a doc page describing all file formats for GWAS, etc.
3. Improve the handling of phenotype and covariate file inputs,
   to be more flexible and also perform a lot more error checking.
4. Restrict "grapp pheno" to diploid GRGs - grg_pheno_sim does not
   currently support non-diploids (I raised an issue there).
5. "grapp filter" based on samples now will reorder the samples
   in the resulting GRG, just like other tools such as bcftools.
   Previous if you specified to only keep samples "0, 10, 5" it
   would keep them in the order "0, 5, 10", whereas now it will
   in fact reorder them properly.
6. Tests for filter command line interface
7. Tests for the end-to-end workflow involving phenotype simulation,
   PCA, and GWAS combined.
8. Switch doc theme