### PR TITLE
Integration with scikit-allel: SFS and joint SFS calculations

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,9 +28,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest black mypy parameterized
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f popgen_requirements.txt ]; then pip install -r popgen_requirements.txt; fi
-        if [ -f test/requirements.txt ]; then pip install -r test/requirements.txt; fi
+        pip install -r requirements.txt
+        pip install -r popgen_requirements.txt
+        pip install -r test/requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest black mypy parameterized
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f popgen_requirements.txt ]; then pip install -r popgen_requirements.txt; fi
         if [ -f test/requirements.txt ]; then pip install -r test/requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+include requirements.txt
+include popgen_requirements.txt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,11 +18,23 @@ grapp is both a tool set and a framework:
 * The *tool set* includes features like filtering (samples and mutations), PCA, GWAS with covariates, phenotype simulation (via `grg_pheno_sim <https://github.com/aprilweilab/grg_pheno_sim>`_), and data export.
 * The *framework* can be used to build tools/methods for statistical and population genetics. The framework contains Python functionality for integrating GRGs with `scipy <https://scipy.org/>`_ and other numerical libraries. In particular, the ``LinearOperator`` functionality can interoperate with many functions in `scipy.sparse.linalg <https://docs.scipy.org/doc/scipy/reference/sparse.linalg.html#module-scipy.sparse.linalg>`_
 
-Both integrate nicely with the Python data analysis ecosystem of `numpy <https://numpy.org>`_, `pandas <https://pandas.pydata.org>`_, and `scipy <https://scipy.org>`_.
+Both integrate nicely with the Python data analysis ecosystem of `numpy <https://numpy.org>`_, `pandas <https://pandas.pydata.org>`_, and `scipy <https://scipy.org>`_. On the popgen side,
+``grapp`` integrates with `scikit-allel <https://scikit-allel.readthedocs.io/en/stable/index.html>`_ (**work in progress**).
 
 The main GRG documentation contains some `tutorials <https://grgl.readthedocs.io/en/latest/tutorials/>`_ on using ``grapp`` for tasks like
 `GWAS <https://grgl.readthedocs.io/en/latest/tutorials/GWAS.html>`_, `PCA <https://grgl.readthedocs.io/en/latest/tutorials/PCA.html>`_, and `LinearOperators <https://grgl.readthedocs.io/en/latest/tutorials/LinearOperators.html>`_, among other tasks.
 
+Basic installation:
+
+::
+
+   pip install grapp
+
+Installation with optional popgen dependencies:
+
+::
+
+   pip install grapp[popgen]
 
 Indices and tables
 ==================

--- a/docs/reference/grapp.rst
+++ b/docs/reference/grapp.rst
@@ -106,3 +106,17 @@ See also "Linear Operators for Multiple GRGs", which is how mathematical operati
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+Population Genetics
+-------------------
+
+.. warning::
+   The popgen functionality in ``grapp`` is in active development; bug reports are very welcome, but
+   the functionality is still undergoing validation and there may be breaking changes to API functions.
+
+.. automodule:: grapp.popgen
+   :members:
+   :imported-members:
+   :undoc-members:
+   :show-inheritance:

--- a/grapp/assoc/__init__.py
+++ b/grapp/assoc/__init__.py
@@ -1,5 +1,10 @@
 from grapp.linalg.ops_scipy import SciPyStdXOperator, SciPyXOperator
-from grapp.util.simple import allele_counts, _GenotypeDist, common_mut_dataframe
+from grapp.util.simple import (
+    allele_counts,
+    _GenotypeDist,
+    common_mut_dataframe,
+    _div_or_default,
+)
 from grapp.util.exceptions import UserInputError
 from grapp.grg_calculator import (
     GRGCalcInterface as _GRGCalcInterface,
@@ -15,18 +20,6 @@ import pygrgl
 import re
 import sklearn.linear_model
 import sys
-
-
-def _div_or_default(a, b, d):
-    """
-    y = a / b, unless b_i is 0, then y_i will be set to 0.
-
-    :param a: Numerator
-    :param b: Denominator
-    :param d: Default value for when denominator is 0.
-    """
-    result = numpy.full(a.shape, d)
-    return numpy.divide(a, b, out=result, where=(b != 0))
 
 
 def read_plink_covariates(

--- a/grapp/cli/polar_cli.py
+++ b/grapp/cli/polar_cli.py
@@ -6,12 +6,19 @@ from grapp.popgen.polarize import (
 from typing import Tuple, Any
 import argparse
 import os
-import pyfaidx
 import pygrgl
 import sys
 
+try:
+    import pyfaidx
+except ImportError:
+    pyfaidx = None
+
 
 def load_fasta(path: str) -> Tuple[Any, str]:
+    assert (
+        pyfaidx is not None
+    ), "Requires 'pyfaidx' module: 'pip install pyfaidx' or 'pip install grapp[popgen]'"
     fasta = pyfaidx.Fasta(path, as_raw=False, sequence_always_upper=True)
     contigs = list(fasta.keys())
     if len(contigs) != 1:

--- a/grapp/popgen/__init__.py
+++ b/grapp/popgen/__init__.py
@@ -1,1 +1,17 @@
 from .polarize import polarize_grg  # noqa: F401
+from .simple import (  # noqa: F401
+    allele_counts,
+    pop_allele_counts,
+    population_pairs,
+    sample_pop_matrix,
+)
+from .sfs import (  # noqa: F401
+    sfs,
+    sfs_scaled,
+    sfs_folded,
+    sfs_folded_scaled,
+    joint_sfs,
+    joint_sfs_scaled,
+    joint_sfs_folded,
+    joint_sfs_folded_scaled,
+)

--- a/grapp/popgen/sfs.py
+++ b/grapp/popgen/sfs.py
@@ -1,0 +1,123 @@
+"""
+Site-frequency-spectrum calculations from data stored in a GRG.
+
+.. note::
+    This module uses scikit-allel. This integration is optional, so "pip install grapp"
+    doesn't install scikit-allel, you need to "pip install scikit-allel" yourself.
+"""
+
+try:
+    import allel
+except ImportError:
+    allel = None  # type: ignore
+import numpy
+import pygrgl
+from grapp.popgen.simple import (
+    allele_counts,
+    pop_allele_counts,
+    population_pairs,
+)
+from typing import List, Tuple, Any
+
+
+def _check_allel():
+    assert (
+        allel is not None
+    ), "Requires 'allel' module: 'pip install scikit-allel' or 'pip install grapp[popgen]"
+
+
+def _single_apply(grg: pygrgl.GRG, folded: bool, sfs_func: Any) -> numpy.typing.NDArray:
+    ac = allele_counts(grg, return_ref=folded)
+    assert ac.ndim == (2 if folded else 1)
+    return sfs_func(ac)
+
+
+def sfs(grg: pygrgl.GRG):
+    _check_allel()
+    return _single_apply(grg, False, allel.sfs)
+
+
+def sfs_scaled(grg: pygrgl.GRG):
+    _check_allel()
+    return _single_apply(grg, False, allel.sfs_scaled)
+
+
+def sfs_folded(grg: pygrgl.GRG):
+    _check_allel()
+    return _single_apply(grg, True, allel.sfs_folded)
+
+
+def sfs_folded_scaled(grg: pygrgl.GRG):
+    _check_allel()
+    return _single_apply(grg, True, allel.sfs_folded_scaled)
+
+
+# Compute all joint SFSs in the GRG, given a particular pairwise-SFS calculation function
+def _joint_apply(
+    grg: pygrgl.GRG, folded: bool, sfs_func: Any
+) -> List[Tuple[int, int, numpy.typing.NDArray]]:
+    _check_allel()
+    pop_ac = pop_allele_counts(grg, return_ref=folded)
+    assert pop_ac.ndim == (3 if folded else 2)
+    result = []
+    for pop1, pop2 in population_pairs(grg):
+        result.append((pop1, pop2, sfs_func(pop_ac[pop1], pop_ac[pop2])))
+    return result
+
+
+def joint_sfs(grg: pygrgl.GRG) -> List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    Return all joint SFSs between all (unique) population pairs in the GRG.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :return: List of ``(pop1, pop2, jSFS)`` where ``pop1``, ``pop2`` are population indices
+        (see ``GRG.get_populations()``). ``jSFS`` is the :math:`\\frac{n1}{2} \\times \\frac{n2}{2}``
+        matrix as emitted by ``allel.joint_sfs_folded``.
+    :rtype: List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    return _joint_apply(grg, False, allel.joint_sfs)
+
+
+def joint_sfs_scaled(grg: pygrgl.GRG) -> List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    Return all scaled joint SFSs between all (unique) population pairs in the GRG.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :return: List of ``(pop1, pop2, jSFS)`` where ``pop1``, ``pop2`` are population indices
+        (see ``GRG.get_populations()``). ``jSFS`` is the :math:`\\frac{n1}{2} \\times \\frac{n2}{2}``
+        matrix as emitted by ``allel.joint_sfs_folded``.
+    :rtype: List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    return _joint_apply(grg, False, allel.joint_sfs_scaled)
+
+
+def joint_sfs_folded(grg: pygrgl.GRG) -> List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    Return all joint folded SFSs between all (unique) population pairs in the GRG.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :return: List of ``(pop1, pop2, jSFS)`` where ``pop1``, ``pop2`` are population indices
+        (see ``GRG.get_populations()``). ``jSFS`` is the :math:`\\frac{n1}{2} \\times \\frac{n2}{2}``
+        matrix as emitted by ``allel.joint_sfs_folded``.
+    :rtype: List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    return _joint_apply(grg, True, allel.joint_sfs_folded)
+
+
+def joint_sfs_folded_scaled(
+    grg: pygrgl.GRG,
+) -> List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    Return all scaled joint folded SFSs between all (unique) population pairs in the GRG.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :return: List of ``(pop1, pop2, jSFS)`` where ``pop1``, ``pop2`` are population indices
+        (see ``GRG.get_populations()``). ``jSFS`` is the :math:`\\frac{n1}{2} \\times \\frac{n2}{2}``
+        matrix as emitted by ``allel.joint_sfs_folded``.
+    :rtype: List[Tuple[int, int, numpy.typing.NDArray]]:
+    """
+    return _joint_apply(grg, True, allel.join_sfs_folded_scaled)

--- a/grapp/popgen/simple.py
+++ b/grapp/popgen/simple.py
@@ -1,0 +1,165 @@
+"""
+Simple counts/statistics based on populations (stored in the GRG) or useful for
+population genetics calculations.
+"""
+
+import itertools
+import numpy
+import pygrgl
+from grapp.util.simple import (
+    _div_or_default,
+    multi_allelic_muts,
+)
+from typing import Tuple, List
+
+
+def population_pairs(grg: pygrgl.GRG) -> List[Tuple[int, int]]:
+    """
+    Return the unique pairs of populations from the given GRG. Equivalent to
+    ``itertools.combinations(reversed(range(P)), 2))`` where ``P`` is the number of
+    populations.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :return: List of pairs of integer indices for populations.
+    :rtype: List[Tuple[int, int]]
+    """
+    populations = grg.get_populations()
+    P = len(populations)
+    assert P >= 1, "No populations in the GRG; cannot get population pairs"
+    return list(itertools.combinations(reversed(range(P)), 2))
+
+
+def sample_pop_matrix(grg: pygrgl.GRG) -> numpy.typing.NDArray:
+    """
+    Given a GRG with :math:`P` populations and :math:`N` samples (haplotypes), return the
+    :math:`P \\times N` matrix, where :math:`A_{i, j} = 1` indicates that sample :math:`j`
+    is in population :math:`i`.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :return: :math:`P \\times N` matrix
+    :rtype: numpy.ndarray
+    """
+    populations = grg.get_populations()
+    P = len(populations)
+    assert P >= 1, "No populations in the GRG; cannot get per-population allele counts"
+
+    sample_pop = numpy.zeros((P, grg.num_samples), dtype=numpy.uint32)
+    # Assigning values to numpy matrices is much more efficient this way than one-at-a-time.
+    samples = list(range(grg.num_samples))
+    pop_ids = list(map(lambda s: grg.get_population_id(s), samples))
+    indices = (pop_ids, samples)
+    sample_pop[indices] = 1
+    return sample_pop
+
+
+def pop_allele_counts(
+    grg: pygrgl.GRG,
+    impute_missing: bool = False,
+    return_ref: bool = False,
+) -> numpy.typing.NDArray:
+    """
+    Get the allele counts by population from a GRG that contains only bi-allelic variants.
+    Each column ``j`` in the output matrix corresponds to the mutation with ID ``j``. Each
+    row ``i`` in the output matrix corresponds to the allele counts for population ``i``,
+    where the order matches ``GRG.get_populations()``.
+
+    .. note::
+        Output is directly compatible with `scikit-allel <https://scikit-allel.readthedocs.io/en/stable/index.html>`_
+        popgen functions.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :param impute_missing: For missing alleles, impute their values as the allele frequency
+        in the population. This results in floating-point numbers for allele counts, so we
+        round to the nearest integer in the result. Default: False.
+    :type impute_missing: bool
+    :param return_ref: If True, return a matrix of dimensions :math:`P \\times M \\times 2`
+        that is compatible with the folded SFS functions from ``scikit-allel` (i.e., the last
+        dimension is ref, alt counts).
+    :type return_ref: bool
+    :return: A matrix (numpy array) of shape :math:`P \\times M`, where :math:`P` is number
+        of populations and :math:`M` is number of mutations in the GRG.
+    :rtype: numpy.ndarray
+    """
+    ma = multi_allelic_muts(grg)
+    assert (
+        len(ma) == 0
+    ), f"GRG must have only bi-allelic sites (found {len(ma)} multi-allelic); try the 'grapp filter' command."
+
+    input_mat = sample_pop_matrix(grg)
+    pop_samples = numpy.sum(input_mat, axis=1)
+    if impute_missing:
+        miss_counts = numpy.zeros(
+            (input_mat.shape[0], grg.num_mutations), dtype=numpy.uint32
+        )
+    else:
+        miss_counts = None
+    acounts = pygrgl.matmul(
+        grg, input_mat, pygrgl.TraversalDirection.UP, miss=miss_counts
+    )
+    if miss_counts is not None:
+        assert miss_counts is not None
+        acounts += numpy.round(
+            miss_counts * _div_or_default(acounts, pop_samples, 0)
+        ).astype(numpy.uint32)
+    if return_ref:
+        # P x M x 2 matrix
+        return numpy.array([(numpy.array([pop_samples]).T - acounts).T, acounts.T]).T
+    # P x M matrix
+    return acounts
+
+
+def allele_counts(
+    grg: pygrgl.GRG,
+    impute_missing: bool = False,
+    return_ref: bool = False,
+) -> numpy.typing.NDArray:
+    """
+    Get the allele counts for all samples from a GRG that contains only bi-allelic variants.
+    Each column ``j`` in the output vector corresponds to the counts for mutation with ID ``j``.
+
+    .. note::
+        Output is directly compatible with `scikit-allel <https://scikit-allel.readthedocs.io/en/stable/index.html>`_
+        popgen functions.
+
+    :param grg: The GRG.
+    :type grg: pygrgl.GRG
+    :param impute_missing: For missing alleles, impute their values as the allele frequency
+        in the population. This results in floating-point numbers for allele counts, so we
+        round to the nearest integer in the result. Default: False.
+    :type impute_missing: bool
+    :param return_ref: If True, return a matrix of dimensions :math:`M \\times 2`
+        that is compatible with the folded SFS functions from ``scikit-allel` (i.e., the last
+        dimension is ref, alt counts).
+    :type return_ref: bool
+    :return: A vector (numpy array) of length :math:`M`, where :math:`M` is number of mutations
+        in the GRG.
+    :rtype: numpy.ndarray
+    """
+    ma = multi_allelic_muts(grg)
+    assert (
+        len(ma) == 0
+    ), f"GRG must have only bi-allelic sites (found {len(ma)} multi-allelic); try the 'grapp filter' command."
+
+    input_mat = numpy.ones((1, grg.num_samples), dtype=numpy.uint32)
+    if impute_missing:
+        miss_counts = numpy.zeros((1, grg.num_mutations), dtype=numpy.uint32)
+    else:
+        miss_counts = None
+    acounts = pygrgl.matmul(
+        grg, input_mat, pygrgl.TraversalDirection.UP, miss=miss_counts
+    )[0]
+    n_j = grg.num_samples
+    if miss_counts is not None:
+        assert miss_counts is not None
+        n_j -= miss_counts[0]
+        acounts += numpy.round(
+            miss_counts[0] * _div_or_default(acounts, n_j, 0)
+        ).astype(numpy.uint32)
+    if return_ref:
+        # M x 2 matrix
+        return numpy.array([(n_j - acounts).T, acounts.T]).T
+    # M-length vector
+    return acounts

--- a/popgen_requirements.txt
+++ b/popgen_requirements.txt
@@ -1,0 +1,2 @@
+pyfaidx
+scikit-allel

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ PACKAGE_NAME = "grapp"
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(THISDIR, "requirements.txt")) as f:
     requirements = list(map(str.strip, f))
+with open(os.path.join(THISDIR, "popgen_requirements.txt")) as f:
+    popgen_reqs = list(map(str.strip, f))
 with open(os.path.join(THISDIR, "README.md")) as f:
     long_description = f.read()
 
@@ -34,6 +36,9 @@ setup(
     install_requires=[
         requirements,
     ],
+    extras_require={
+        "popgen": popgen_reqs,
+    },
     long_description=long_description,
     long_description_content_type="text/markdown",
     entry_points={

--- a/test/popgen/test_pg_simple.py
+++ b/test/popgen/test_pg_simple.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import unittest
+import numpy
+import pygrgl
+from grapp.popgen import (
+    allele_counts,
+    pop_allele_counts,
+    population_pairs,
+    sample_pop_matrix,
+)
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(THIS_DIR, ".."))
+from testing_utils import make_grg_sparse_mat
+
+INPUT_DIR = os.path.join(THIS_DIR, "..", "input")
+
+
+class TestSimple(unittest.TestCase):
+    def setUp(cls):
+        # 4 samples, 6 variants.
+        cls.gt = numpy.array(
+            [
+                [0, 1, 1, 0, 0, 1],
+                [1, 0, 1, 1, 0, 1],
+                [1, 0, 1, 1, 0, 1],
+                [0, 1, 0, 1, 1, 1],
+            ]
+        )
+        # pop_sample_matrix - 3 populations, 4 samples
+        cls.psm = numpy.array(
+            [
+                [0, 1, 0, 0],
+                [1, 0, 1, 0],
+                [0, 0, 0, 1],
+            ]
+        )
+        cls.grg = make_grg_sparse_mat(
+            list(range(6)), ["A"] * 6, ["T"] * 6, cls.gt, pop_sample_matrix=cls.psm
+        )
+
+    def test_pop_matrix(self):
+        result = sample_pop_matrix(self.grg)
+        numpy.testing.assert_equal(self.psm, result)
+
+    def test_pop_pairs(self):
+        self.assertEqual([(2, 1), (2, 0), (1, 0)], population_pairs(self.grg))
+
+    def test_pop_ac(self):
+        pop_ac = pop_allele_counts(self.grg, return_ref=False)
+        self.assertEqual(pop_ac.shape, (3, 6))
+        numpy.testing.assert_equal(
+            [
+                [1, 0, 1, 1, 0, 1],  # pop0
+                [1, 1, 2, 1, 0, 2],  # pop1
+                [0, 1, 0, 1, 1, 1],  # pop2
+            ],
+            pop_ac,
+        )
+
+        # return_ref=True adds another dimension, showing the REF count
+        pop_ac = pop_allele_counts(self.grg, return_ref=True)
+        self.assertEqual(pop_ac.shape, (3, 6, 2))
+        numpy.testing.assert_equal(
+            [
+                [(0, 1), (1, 0), (0, 1), (0, 1), (1, 0), (0, 1)],  # pop0
+                [(1, 1), (1, 1), (0, 2), (1, 1), (2, 0), (0, 2)],  # pop1
+                [(1, 0), (0, 1), (1, 0), (0, 1), (0, 1), (0, 1)],  # pop2
+            ],
+            pop_ac,
+        )
+
+    def test_ac(self):
+        ac = allele_counts(self.grg, return_ref=False)
+        self.assertEqual(ac.shape, (6,))
+        numpy.testing.assert_equal(
+            [2, 2, 3, 3, 1, 4],
+            ac,
+        )
+
+        ac = allele_counts(self.grg, return_ref=True)
+        self.assertEqual(ac.shape, (6, 2))
+        numpy.testing.assert_equal(
+            [(2, 2), (2, 2), (1, 3), (1, 3), (3, 1), (0, 4)],
+            ac,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/popgen/test_sfs.py
+++ b/test/popgen/test_sfs.py
@@ -1,0 +1,100 @@
+import os
+import sys
+import unittest
+import numpy
+import pygrgl
+from grapp.popgen import (
+    sfs,
+    sfs_scaled,
+    sfs_folded,
+    sfs_folded_scaled,
+    joint_sfs,
+    joint_sfs_scaled,
+    joint_sfs_folded,
+    joint_sfs_folded_scaled,
+)
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(THIS_DIR, ".."))
+from testing_utils import make_grg_sparse_mat
+
+INPUT_DIR = os.path.join(THIS_DIR, "..", "input")
+
+
+class TestSFS(unittest.TestCase):
+    def setUp(cls):
+        # 5 samples, 8 variants.
+        cls.gt = numpy.array(
+            [
+                [0, 1, 1, 0, 0, 1, 0, 0],
+                [1, 0, 1, 1, 0, 1, 0, 1],
+                [1, 0, 1, 1, 0, 1, 0, 0],
+                [0, 1, 0, 1, 1, 1, 1, 0],
+                [0, 1, 0, 1, 1, 1, 1, 1],
+            ]
+        )
+        # pop_sample_matrix - 3 populations, 5 samples
+        cls.psm = numpy.array(
+            [
+                [0, 1, 0, 0, 1],
+                [1, 0, 1, 0, 0],
+                [0, 0, 0, 1, 0],
+            ]
+        )
+        cls.grg = make_grg_sparse_mat(
+            list(range(8)), ["A"] * 8, ["T"] * 8, cls.gt, pop_sample_matrix=cls.psm
+        )
+
+    def test_sfs(self):
+        # The simple SFS over all populations
+        s = sfs(self.grg)
+        numpy.testing.assert_equal([0, 0, 4, 2, 1, 1], s)
+
+        # Just make sure the scaled versions don't barf
+        s = sfs_scaled(self.grg)
+        self.assertEqual((self.grg.num_samples + 1,), s.shape)
+        s = sfs_folded_scaled(self.grg)
+        self.assertEqual(((self.grg.num_samples // 2) + 1,), s.shape)
+
+        # Folded
+        s = sfs_folded(self.grg)
+        numpy.testing.assert_equal([1, 1, 6], s)
+
+    def test_joint_sfs(self):
+        def _get_pair(a, b, list_of_results):
+            for pop1, pop2, sfs in list_of_results:
+                if (pop1, pop2) == (a, b):
+                    return sfs
+            return None
+
+        # Pop0:
+        #                [1, 0, 1, 1, 0, 1, 0, 1],
+        #                [0, 1, 0, 1, 1, 1, 1, 1],
+        # Pop1:
+        #                [0, 1, 1, 0, 0, 1, 0, 0],
+        #                [1, 0, 1, 1, 0, 1, 0, 0],
+        # Pop2:
+        #                [0, 1, 0, 1, 1, 1, 1, 0],
+
+        # The joint SFS for each unique population pair
+        jsfs_list = joint_sfs(self.grg)
+
+        # pop1, pop0  (the order is always larger index on y-axis)
+        numpy.testing.assert_equal(
+            [[0, 2, 1], [0, 2, 1], [0, 1, 1]],  # pop0 --->  # pop1  #  |  #  V
+            _get_pair(1, 0, jsfs_list),
+        )
+
+        # pop2, pop1  (the order is always larger index on y-axis)
+        numpy.testing.assert_equal(
+            [  # pop1 --->
+                [1, 1, 1],  # pop2
+                [2, 2, 1],  #  |
+                #  V
+            ],
+            _get_pair(2, 1, jsfs_list),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/popgen/test_sfs.py
+++ b/test/popgen/test_sfs.py
@@ -2,7 +2,7 @@ import os
 import sys
 import unittest
 import numpy
-import pygrgl
+import pytest
 from grapp.popgen import (
     sfs,
     sfs_scaled,
@@ -21,6 +21,9 @@ from testing_utils import make_grg_sparse_mat
 INPUT_DIR = os.path.join(THIS_DIR, "..", "input")
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="scikit-allel requires python3.10 or higher"
+)
 class TestSFS(unittest.TestCase):
     def setUp(cls):
         # 5 samples, 8 variants.

--- a/test/testing_utils.py
+++ b/test/testing_utils.py
@@ -243,6 +243,7 @@ def make_grg_sparse_mat(
     matrix: numpy.typing.NDArray,
     miss: Optional[numpy.typing.NDArray] = None,
     ploidy: int = 1,
+    pop_sample_matrix: Optional[numpy.typing.NDArray] = None,
 ) -> pygrgl.GRG:
     """
     Create a GRG that is equivalent to the sparse matrix representations of the given genotype
@@ -285,4 +286,13 @@ def make_grg_sparse_mat(
             mut_node,
             miss_node,
         )
+
+    if pop_sample_matrix is not None:
+        pops = [f"pop_{i}" for i in range(pop_sample_matrix.shape[0])]
+        for p in pops:
+            g.add_population(p)
+        for p in range(pop_sample_matrix.shape[0]):
+            samples_for_p = numpy.flatnonzero(pop_sample_matrix[p])
+            for s in samples_for_p:
+                g.set_population_id(s, p)
     return g


### PR DESCRIPTION
`grapp.popgen` now supports extracting allele count output that is directly compatible with many scikit-allel popgen functions. Specifically, we can now extract per-population allele counts, and extract the ref/alt allele counts in a matrix form that can be passed directly to scikit-allel's folded SFS functionality.

`grapp.popgen.sfs` also contains wrappers around scikit-allel that will compute SFS information for all population pairs, e.g. for extracting the joint SFS information for demographic inference.

This functionality is still a work in progress, and APIs may change. The f-statistics (both classical and admixture ones) from scikit-allel should also be compatible with `grapp.popgen`, and at some point I will add wrappers for those as well.