### PR TITLE
New "grapp ts2igd" command

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -100,6 +100,13 @@ grapp show -S input.grg > individuals.txt
 grapp export --igd output.igd -j 6 input.grg
 ```
 
+#### Export tskit TreeSequence to IGD format (tabular)
+
+```
+# The more threads (-j) the better!
+grapp ts2igd -j 6 input.trees output.igd
+```
+
 ### GWAS, PCA, and phenotypes
 
 #### Phenotype simulation

--- a/docs/howto/cli_recipes.rst
+++ b/docs/howto/cli_recipes.rst
@@ -119,3 +119,12 @@ GRG to IGD
 
     # This can be slow! Use more threads (-j) if possible
     grapp export -j 4 my_input.grg --igd exported.igd
+
+
+tskit TreeSequence to IGD
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    # This can be slow! Use more threads (-j) if possible
+    grapp ts2igd -j 4 my_input.trees exported.igd

--- a/grapp/cli/main.py
+++ b/grapp/cli/main.py
@@ -6,6 +6,7 @@ from grapp.cli import pca_cli
 from grapp.cli import show_cli
 from grapp.cli import pheno_cli
 from grapp.cli import polar_cli
+from grapp.cli import ts2igd_cli
 from grapp.util.exceptions import UserInputError
 
 import argparse
@@ -19,6 +20,7 @@ CMD_FILTER = "filter"
 CMD_SHOW = "show"
 CMD_PHENO = "pheno"
 CMD_POLARIZE = "polarize"
+CMD_TS2IGD = "ts2igd"
 
 
 def main():
@@ -63,7 +65,12 @@ def main():
         CMD_POLARIZE,
         help="Polarize a GRG using an ancestral sequence.",
     )
-    polar_cli.add_options(polar_parser)
+    ts2igd_cli.add_options(polar_parser)
+    ts2igd_parser = subparsers.add_parser(
+        CMD_TS2IGD,
+        help="Convert tskit TreeSequence to IGD.",
+    )
+    ts2igd_cli.add_options(ts2igd_parser)
 
     try:
         args = parser.parse_args()
@@ -87,6 +94,8 @@ def main():
             pheno_cli.run(args)
         elif args.command == CMD_POLARIZE:
             polar_cli.run(args)
+        elif args.command == CMD_TS2IGD:
+            ts2igd_cli.run(args)
         else:
             print(f"Invalid command {args.command}", file=sys.stderr)
             parser.print_help()

--- a/grapp/cli/ts2igd_cli.py
+++ b/grapp/cli/ts2igd_cli.py
@@ -1,0 +1,61 @@
+import argparse
+import pygrgl
+import os
+
+from grapp.util.igd import export_igd
+from grapp.util.parallel import _get_temp_dir_context
+
+
+def add_options(subparser):
+    subparser.add_argument(
+        "ts_input", help="The input tskit TreeSequence (.trees) file"
+    )
+    subparser.add_argument("igd_output", help="The output filename (.igd)")
+    subparser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Force overwrite of the output file, if it exists.",
+    )
+    subparser.add_argument(
+        "-j",
+        "--jobs",
+        default=1,
+        type=int,
+        help="Number of processes/threads to use, if possible. Default: 1.",
+    )
+    subparser.add_argument(
+        "--temp-dir",
+        help="Put all temporary files in the given directory, instead of creating a directory in "
+        "the system temporary location. WARNING: Intermediate/temporary files will not be cleaned "
+        "up when this is specified.",
+    )
+
+
+VERBOSE = True
+
+
+def run(args):
+    assert args.force or not os.path.exists(
+        args.igd_output
+    ), f"{args.igd_output} already exists; remove it or use --force"
+    assert os.path.isfile(args.ts_input), f"{args.ts_input} does not exist"
+
+    # Convert TS->GRG
+    grg = pygrgl.grg_from_trees(args.ts_input)
+
+    # Simplifying the GRG by writing it to disk and reloading it is worthwhile! It speeds up
+    # the IGD conversion by quite a lot.
+    with _get_temp_dir_context(args.temp_dir)() as tmpdirname:
+        pygrgl.save_grg(grg, "simplify.grg")
+        grg = pygrgl.load_immutable_grg("simplify.grg", load_up_edges=False)
+
+    # Convert GRG->IGD
+    export_igd(grg, args.igd_output, args.jobs, verbose=VERBOSE, temp_dir=args.temp_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    add_options(parser)
+    args = parser.parse_args()
+    run(args)

--- a/grapp/util/igd.py
+++ b/grapp/util/igd.py
@@ -11,6 +11,7 @@ import numpy
 import os
 import pygrgl
 import pyigd
+import shutil
 import sys
 import tempfile
 
@@ -152,7 +153,11 @@ def export_igd(
         filename_list: List[str],
         context: Dict[str, Any],
     ):
+        assert len(filename_list) > 0, "No IGDs to be merged"
         if no_merge:
+            return
+        if len(filename_list) == 1:
+            shutil.copy(filename_list[0], out_filename)
             return
         in_files = [open(fn, "rb") for fn in filename_list]
         try:


### PR DESCRIPTION
When you have a really large simulated dataset, it can be quite slow to use "tskit vcf | bgzip -c > out.vcf.gz" to export it to a tabular format (VCF). VCF can be convenient, because of all the tools that support it, but for really large datasets it is pretty slow also.

You can convert quickly from tskit to GRG, and then from GRG to IGD (which is faster to traverse than VCF, though will less tool support). This change adds a command "grapp ts2igd" to do that conversion in a single step.